### PR TITLE
Add ubuntu to source build test, run on pushes and PRs

### DIFF
--- a/.github/workflows/test-src-build.yml
+++ b/.github/workflows/test-src-build.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu:focal, alpine:3.14]
-        arch: [linux/amd64, linux/arm64, linux/arm/v7]
+        distro: ["ubuntu:focal", "alpine:3.14"]
+        arch: ["linux/amd64", "linux/arm64", "linux/arm/v7"]
 
     steps:
       - uses: actions/checkout@v2

--- a/docker/from_src.Dockerfile
+++ b/docker/from_src.Dockerfile
@@ -27,6 +27,12 @@ RUN \
     apt-get update && \
     apt-get install -y \
       python3-pip \
+      libaom-dev \
+      libfribidi-dev \
+      libharfbuzz-dev \
+      libjpeg-dev \
+      liblcms2-dev \
+      libffi-dev \
       libtool \
       git \
       cmake; \

--- a/docker/from_src.Dockerfile
+++ b/docker/from_src.Dockerfile
@@ -27,7 +27,6 @@ RUN \
     apt-get update && \
     apt-get install -y \
       python3-pip \
-      libaom-dev \
       libfribidi-dev \
       libharfbuzz-dev \
       libjpeg-dev \


### PR DESCRIPTION
On ubuntu, there are no prebuilt wheels for the dependencies on armhf (just like alpine) so I had to add the deps for those as well, including aom. On armhf, pillow_heif and its dependencies are all built from source.

With this PR, pillow_heif builds from source successfully, however the tests fail on ubuntu (they pass on alpine). I have no idea why, but you're the expert on that ;)

Here's the last action log based on these commits: https://github.com/aptalca/pillow_heif/runs/5454210643?check_suite_focus=true