### PR TITLE
Resolves #44 (Pillow 9.3.0 WEBP EXIF changes)

### DIFF
--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -34,7 +34,9 @@ def set_orientation(info: dict, orientation: int = 1) -> Union[int, None]:
 
     original_orientation = None
     if info.get("exif", None):
-        tif_tag = info["exif"][6:]
+        tif_tag = info["exif"]
+        if tif_tag.startswith(b"Exif\x00\x00"):
+            tif_tag = tif_tag[6:]
         endian_mark = "<" if tif_tag[0:2] == b"\x49\x49" else ">"
         pointer = unpack(endian_mark + "L", tif_tag[4:8])[0]
         tag_count = unpack(endian_mark + "H", tif_tag[pointer : pointer + 2])[0]

--- a/pillow_heif/private.py
+++ b/pillow_heif/private.py
@@ -159,7 +159,7 @@ def retrieve_exif(metadata: list):
     for i, md_block in enumerate(metadata):
         if md_block["type"] == "Exif":
             _purge.append(i)
-            if not _result and md_block["data"] and md_block["data"][0:4] == b"Exif":
+            if not _result and md_block["data"]:
                 _result = md_block["data"]
     for i in reversed(_purge):
         del metadata[i]


### PR DESCRIPTION
Fixes #44

Changes proposed in this pull request:

 * `set_orientation` helper function do not skip first 6 bytes of EXIF data if it does not start with `b'Exif'`
 * private `retrieve_exif` do not check EXIF data to start with `b'Exif'`, allows to store anything in EXIF field.
