### PR TITLE
Using `getxmp` from Pillow(min Pillow 8.3.0)

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Install from source
         run: |
-          python -m pip install opencv-python coverage pillow==8.1.0
+          python -m pip install opencv-python coverage pillow==8.4.0
           python -m pip -v install ".[tests]"
 
       - name: LibHeif info

--- a/pi-heif/setup.cfg
+++ b/pi-heif/setup.cfg
@@ -39,7 +39,7 @@ zip_safe = False
 packages = find:
 install_requires =
     cffi>=1.14.6
-    pillow>=6.2.0
+    pillow>=8.3.0
 
 [options.extras_require]
 tests =

--- a/pillow_heif/__init__.py
+++ b/pillow_heif/__init__.py
@@ -29,5 +29,5 @@ from .heif import (
     open_heif,
     read_heif,
 )
-from .misc import get_file_mimetype, getxmp, set_orientation
+from .misc import get_file_mimetype, set_orientation
 from .thumbnails import add_thumbnails, thumbnail

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -12,7 +12,7 @@ from ._options import options
 from .constants import HeifCompressionFormat, HeifErrorCode
 from .error import HeifError
 from .heif import HeifFile, open_heif
-from .misc import _get_bytes, getxmp, set_orientation
+from .misc import _get_bytes, set_orientation
 
 
 class _LibHeifImageFile(ImageFile.ImageFile):
@@ -61,7 +61,11 @@ class _LibHeifImageFile(ImageFile.ImageFile):
 
         :returns: XMP tags in a dictionary."""
 
-        return getxmp(self.info["xmp"])
+        if self.info.get("xmp", None):
+            xmp_data = self.info["xmp"].rsplit(b"\x00", 1)
+            if xmp_data[0]:
+                return self._getxmp(xmp_data[0])
+        return {}
 
     def seek(self, frame):
         if not self._seek_check(frame):

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ zip_safe = False
 packages = find:
 install_requires =
     cffi>=1.14.6
-    pillow>=8.4.0
+    pillow>=8.3.0
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ zip_safe = False
 packages = find:
 install_requires =
     cffi>=1.14.6
-    pillow>=6.2.0
+    pillow>=8.4.0
 
 [options.extras_require]
 docs =

--- a/tests/orientation_test.py
+++ b/tests/orientation_test.py
@@ -2,9 +2,7 @@ from io import BytesIO
 
 import pytest
 from helpers import assert_image_similar, hevc_enc
-from packaging.version import parse as parse_version
 from PIL import Image, ImageOps
-from PIL import __version__ as pil_version
 
 import pillow_heif
 
@@ -43,7 +41,6 @@ def get_xmp_with_orientation(orientation: int, style=1) -> str:
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
-@pytest.mark.skipif(parse_version(pil_version) < parse_version("8.3.0"), reason="Requires Pillow >= 8.3")
 @pytest.mark.parametrize("orientation", (1, 2, 3, 4, 5, 6, 7, 8))
 @pytest.mark.parametrize("im_format", ("JPEG", "PNG"))
 def test_exif_orientation(orientation, im_format):
@@ -68,7 +65,6 @@ def test_exif_orientation(orientation, im_format):
             assert_image_similar(im, im_heif)
 
 
-@pytest.mark.skipif(parse_version(pil_version) < parse_version("8.3.0"), reason="Requires Pillow >= 8.3")
 @pytest.mark.parametrize("orientation", (1, 2, 3, 4, 5, 6, 7, 8))
 def test_png_xmp_orientation(orientation):
     im = Image.effect_mandelbrot((256, 128), (-3, -2.5, 2, 2.5), 100).crop((0, 0, 256, 96))
@@ -161,7 +157,6 @@ def test_heif_xmp_orientation_with_exif_eq_1(orientation):
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
-@pytest.mark.skipif(parse_version(pil_version) < parse_version("8.3.0"), reason="Requires Pillow >= 8.3")
 @pytest.mark.parametrize("orientation", (1, 2))
 @pytest.mark.parametrize("im_format", ("JPEG", "PNG"))
 def test_exif_heif_exif_orientation(orientation, im_format):

--- a/tests/read_test.py
+++ b/tests/read_test.py
@@ -202,7 +202,6 @@ def test_heif_read_images(image_path):
     def test_read_image(convert_hdr_to_8bit: bool) -> bool:
         heif_file = pillow_heif.open_heif(image_path, convert_hdr_to_8bit=convert_hdr_to_8bit)
         for image in heif_file:
-            assert isinstance(pillow_heif.getxmp(image.info["xmp"]), dict)
             assert min(image.size) > 0
             assumed_mode = "RGBA" if image.has_alpha else "RGB"
             if image.bit_depth > 8:
@@ -294,12 +293,6 @@ def test_heif_index():
         del heif_file[-1]
     with pytest.raises(IndexError):
         del heif_file[len(heif_file)]
-
-
-@mock.patch("pillow_heif.misc.ElementTree", None)
-def test_no_defusedxml(monkeypatch):
-    with pytest.warns(UserWarning):
-        pillow_heif.getxmp(b"xmp_data")
 
 
 def test_read_heif():


### PR DESCRIPTION
Changes proposed in this pull request:

 * Minimum required Pillow increased from `6.2.0` to `8.3.0`
 * `getxmp` used from Pillow
 
 For version `0.9.0`
