### PR TITLE
removing `RGBa` -> `RGB` conversion

### DIFF
--- a/docs/image-modes.rst
+++ b/docs/image-modes.rst
@@ -78,4 +78,4 @@ Modes with premultiplied Alpha:
     * ``RGBa;12``  -->  ``RGBa;16`` or ``BGRa;16``
     * ``RGBa;10``  -->  ``RGBa;16`` or ``BGRa;16``
     * ``BGRa``  -->  ``RGBa``
-    * ``RGBa`` --> ``RGB``, ``BGR``, ``RGBa;16`` or ``BGRa;16``
+    * ``RGBa`` --> ``BGRa``, ``RGBa;16`` or ``BGRa;16``

--- a/pillow_heif/helpers.c
+++ b/pillow_heif/helpers.c
@@ -484,44 +484,6 @@ void convert_bgr_rgb(const uint8_t *in, int in_stride, uint8_t *out, int out_str
     }
 }
 
-void convert_rgba_premultiplied_to_rgb(const uint8_t *in, int in_stride, uint8_t *out, int out_stride, int n_rows)
-{
-    const uint32_t* in_row = (uint32_t*)in;
-    uint8_t* out_row = out;
-    in_stride = in_stride / 4;
-    int stride_elements = out_stride / 3 > in_stride ? in_stride : out_stride / 3;
-    for (int i = 0; i < n_rows; i++) {
-        for (int i2 = 0; i2 < stride_elements; i2++) {
-            uint32_t p = in_row[i2];
-            uint8_t a =  (p >> 24) & 0xFF;
-            out_row[i2 * 3 + 0] = (((p >> 0) & 0xFF) * a) / 255;
-            out_row[i2 * 3 + 1] = (((p >> 8) & 0xFF) * a) / 255;
-            out_row[i2 * 3 + 2] = (((p >> 16) & 0xFF) * a) / 255;
-        }
-        in_row += in_stride;
-        out_row += out_stride;
-    }
-}
-
-void convert_rgba_premultiplied_to_bgr(const uint8_t *in, int in_stride, uint8_t *out, int out_stride, int n_rows)
-{
-    const uint32_t* in_row = (uint32_t*)in;
-    uint8_t* out_row = out;
-    in_stride = in_stride / 4;
-    int stride_elements = out_stride / 3 > in_stride ? in_stride : out_stride / 3;
-    for (int i = 0; i < n_rows; i++) {
-        for (int i2 = 0; i2 < stride_elements; i2++) {
-            uint32_t p = in_row[i2];
-            uint8_t a =  (p >> 24) & 0xFF;
-            out_row[i2 * 3 + 0] = (((p >> 16) & 0xFF) * a) / 255;
-            out_row[i2 * 3 + 1] = (((p >> 8) & 0xFF) * a) / 255;
-            out_row[i2 * 3 + 2] = (((p >> 0) & 0xFF) * a) / 255;
-        }
-        in_row += in_stride;
-        out_row += out_stride;
-    }
-}
-
 #ifdef __cplusplus
     }
 #endif

--- a/pillow_heif/helpers.h
+++ b/pillow_heif/helpers.h
@@ -49,7 +49,3 @@ void convert_rgb_to_bgr16(const uint8_t *in, int in_stride, uint8_t *out, int ou
 void convert_bgra_rgba(const uint8_t *in, int in_stride, uint8_t *out, int out_stride, int n_rows);
 
 void convert_bgr_rgb(const uint8_t *in, int in_stride, uint8_t *out, int out_stride, int n_rows);
-
-void convert_rgba_premultiplied_to_rgb(const uint8_t *in, int in_stride, uint8_t *out, int out_stride, int n_rows);
-
-void convert_rgba_premultiplied_to_bgr(const uint8_t *in, int in_stride, uint8_t *out, int out_stride, int n_rows);

--- a/pillow_heif/private.py
+++ b/pillow_heif/private.py
@@ -71,8 +71,6 @@ MODE_CONVERT = {
         "BGRa": lib.convert_bgra_rgba,
         "RGBa;16": lib.convert_rgba_to_rgba16,
         "BGRa;16": lib.convert_rgba_to_bgra16,
-        "RGB": lib.convert_rgba_premultiplied_to_rgb,
-        "BGR": lib.convert_rgba_premultiplied_to_bgr,
     },
     "RGB": {"BGR": lib.convert_bgr_rgb, "RGB;16": lib.convert_rgb_to_rgb16, "BGR;16": lib.convert_rgb_to_bgr16},
 }

--- a/tests/mode_convert_test.py
+++ b/tests/mode_convert_test.py
@@ -116,36 +116,3 @@ def test_rgba16_to_rgba_color_mode():
     heif_file.convert_to("RGBA;16")
     heif_file.convert_to("RGBA")
     helpers.assert_image_similar(heif_file.to_pillow(), heif_file_orig.to_pillow())
-
-
-def test_rgba_premultiplied_to_rgb():
-    im_heif = from_pillow(helpers.gradient_rgba().crop((124, 124, 132, 132)))
-    im_heif.premultiplied_alpha = True
-    assert im_heif.mode == "RGBa"
-    im_heif.convert_to("RGB")
-    assert im_heif.mode == "RGB"
-    assert (
-        im_heif.to_pillow().tobytes().hex()
-        == "3f3f433f3f423e3f423e3f413d3f413d3f403c3f403c3f3f403f423f3f423f3f413e3f413e3f4"
-        "03d3f403d3f3f3c3f3f403f42403f413f3f413f3f403e3f403e3f3f3d3f3f3d3f3e413f41403f"
-        "41403f403f3f403f3f3f3e3f3f3e3f3e3d3f3e413f41413f40403f40403f3f3f3f3f3f3f3e3e3"
-        "f3e3e3f3d423f40413f40413f3f403f3f403f3e3f3f3e3f3f3d3e3f3d423f40423f3f413f3f41"
-        "3f3e403f3e403f3d3f3f3d3f3f3c433f3f423f3f423f3e413f3e413f3d403f3d403f3c3f3f3c"
-    )
-
-
-def test_rgba_premultiplied_to_bgr():
-    im_heif = from_pillow(helpers.gradient_rgba().crop((124, 124, 132, 132)))
-    im_heif.premultiplied_alpha = True
-    assert im_heif.mode == "RGBa"
-    im_heif.convert_to("BGR")
-    assert im_heif.mode == "BGR"
-    im_heif.convert_to("RGB")
-    assert (
-        im_heif.to_pillow().tobytes().hex()
-        == "3f3f433f3f423e3f423e3f413d3f413d3f403c3f403c3f3f403f423f3f423f3f413e3f413e3f4"
-        "03d3f403d3f3f3c3f3f403f42403f413f3f413f3f403e3f403e3f3f3d3f3f3d3f3e413f41403f"
-        "41403f403f3f403f3f3f3e3f3f3e3f3e3d3f3e413f41413f40403f40403f3f3f3f3f3f3f3e3e3"
-        "f3e3e3f3d423f40413f40413f3f403f3f403f3e3f3f3e3f3f3d3e3f3d423f40423f3f413f3f41"
-        "3f3e403f3e403f3d3f3f3d3f3f3c433f3f423f3f423f3e413f3e413f3d403f3d403f3c3f3f3c"
-    )


### PR DESCRIPTION
Pillow starting from next release probably will support this conversion itself(https://github.com/python-pillow/Pillow/issues/6706) so it is not needed to have it's implementation here.
