### PR TITLE
Win: enabled `DECODE_THREADS` test

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -120,7 +120,6 @@ jobs:
     name: Coverage(Windows)
     env:
       MSYS2_PREFIX: "C:/temp/msys64/mingw64"
-      TEST_DECODE_THREADS: 0    # Till `MSYS2` update to `1.14.1`
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Windows: MSYS2 updated their packages to libheif version `1.14.2`. Enabling test for multiply threads decode.