### PR TITLE
updated libde265 from 1.0.11 to 1.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This release is fully compatible with `0.10.x+` versions.
 
 - (Heif) restored lost ability after `0.9.x` versions to open HDR images in 10/12 bit. #96
 
+### Changed
+
+- `libde265`(HEIF decoder) updated from 1.0.11 to 1.0.12 version. [changelog](https://github.com/strukturag/libde265/releases/tag/v1.0.12)
+
 ## Fixed
 
 - (Heif) `encode` function with `stride` argument correctly saves image.

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -11,8 +11,8 @@ Files: libheif.[dylib|so|dll]
 Name: libde265
 License: LGPLv3
 Files: libde265.[dylib|so|dll]
-  For details, see https://github.com/strukturag/libde265/tree/v1.0.11/COPYING
-  Source code: https://github.com/strukturag/libde265/tree/v1.0.11
+  For details, see https://github.com/strukturag/libde265/tree/v1.0.12/COPYING
+  Source code: https://github.com/strukturag/libde265/tree/v1.0.12
 
 Name: x265
 License: GPLv2

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -10,7 +10,7 @@ PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"
 
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/get/0b75c44c10e605fe9e9ebed58f04a46271131827.tar.gz"
 LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.5.0.tar.gz"
-LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.11/libde265-1.0.11.tar.gz"
+LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.12/libde265-1.0.12.tar.gz"
 LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.15.2/libheif-1.15.2.tar.gz"
 
 

--- a/pi-heif/LICENSES_bundled.txt
+++ b/pi-heif/LICENSES_bundled.txt
@@ -11,5 +11,5 @@ Files: libheif.[dylib|so|dll]
 Name: libde265
 License: LGPLv3
 Files: libde265.[dylib|so|dll]
-  For details, see https://github.com/strukturag/libde265/tree/v1.0.11/COPYING
-  Source code: https://github.com/strukturag/libde265/tree/v1.0.11
+  For details, see https://github.com/strukturag/libde265/tree/v1.0.12/COPYING
+  Source code: https://github.com/strukturag/libde265/tree/v1.0.12


### PR DESCRIPTION
libde265 changelog:

Fixed 2 CVEs
 * https://nvd.nist.gov/vuln/detail/CVE-2023-27102
 * https://nvd.nist.gov/vuln/detail/CVE-2023-27103
