### PR TITLE
Fixes `Analyse-coverage` on Linux with `ppa:strukturag/libheif`

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Prepare system
         run: |
           sudo apt -y purge libheif1
-          sudo apt -y install libaom-dev libx265-dev libde265-dev nasm
           sudo add-apt-repository ppa:strukturag/libheif
           sudo apt update
           sudo apt -y install libheif-dev
@@ -90,7 +89,6 @@ jobs:
       - name: Prepare system
         run: |
           sudo apt -y purge libheif1
-          sudo apt -y install libaom-dev libx265-dev libde265-dev nasm
           sudo add-apt-repository ppa:strukturag/libheif
           sudo apt update
           sudo apt -y install libheif-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This release is fully compatible with `0.10.x+` versions.
 
 ## Fixed
 
+- Building from source when using `apt-repository ppa:strukturag/libheif`
 - (Heif) `encode` function with `stride` argument correctly saves image.
 - (Heif) HeifFile class created with `from_bytes` function with `stride` argument respect `stride` value during save.
 - (Heif) HeifFile class created with `from_bytes` function with `stride` argument can correctly translate to numpy array.

--- a/libheif/macos/libheif.rb
+++ b/libheif/macos/libheif.rb
@@ -9,6 +9,7 @@ class Libheif < Formula
   # Set current revision from what it was taken plus 10
   revision 10
 
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "aom"
   depends_on "jpeg-turbo"
@@ -18,8 +19,16 @@ class Libheif < Formula
   depends_on "x265"
 
   def install
-    system "./configure", *std_configure_args, "--disable-silent-rules"
-    system "make", "install"
+    args = %W[
+      -DWITH_RAV1E=OFF
+      -DWITH_DAV1D=OFF
+      -DWITH_SvtEnc=OFF
+      -DENABLE_PLUGIN_LOADING=OFF
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+    ]
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
     pkgshare.install "examples/example.heic"
     pkgshare.install "examples/example.avif"
   end

--- a/pi-heif/libheif/macos/libheif.rb
+++ b/pi-heif/libheif/macos/libheif.rb
@@ -9,11 +9,22 @@ class Libheif < Formula
   # Set current revision from what it was taken plus 10
   revision 10
 
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "libde265"
 
   def install
-    system "./configure", *std_configure_args, "--disable-silent-rules"
-    system "make", "install"
+    args = %W[
+      -DWITH_RAV1E=OFF
+      -DWITH_DAV1D=OFF
+      -DWITH_SvtEnc=OFF
+      -DWITH_AOM=OFF
+      -DWITH_X265=OFF
+      -DENABLE_PLUGIN_LOADING=OFF
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+    ]
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 end

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -1169,6 +1169,10 @@ static int setup_module(PyObject* m) {
     if (PyType_Ready(&CtxImage_Type) < 0)
         return -1;
 
+    #if LIBHEIF_HAVE_VERSION(1,14,0)
+        heif_init(NULL);
+    #endif
+
     const struct heif_encoder_descriptor* encoder_descriptor;
     const char* x265_version = "";
     if (heif_context_get_encoder_descriptors(NULL, heif_compression_HEVC, NULL, &encoder_descriptor, 1))


### PR DESCRIPTION
After libheif updated their builds in their PPA repo, Linux actions started to fail.

There was wrong description of `heif_init` function: strukturag/libheif/issues/909

So here are the fix:

 * Added call to `heif_init` when `libheif` version is greater then 1.14.0
 * Switched to `cmake` for macOS builds(Linux/Windows is already switched long time ago)
 * On macOS added `-DENABLE_PLUGIN_LOADING=OFF` path to `cmake`(Linux/Windows builds is already has this flag)