### PR TITLE
Add Python 3.12 to the test matrix / wheels build

### DIFF
--- a/.github/workflows/test-wheels-pi_heif.yml
+++ b/.github/workflows/test-wheels-pi_heif.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     env:
       PH_LIGHT_ACTION: 1
 
@@ -107,7 +107,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        python-version: ["pypy-3.8", "pypy-3.9", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["pypy-3.8", "pypy-3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Delay, waiting Pypi to update.
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["pypy-3.8", "pypy-3.9", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["pypy-3.8", "pypy-3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Delay, waiting Pypi to update.

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     env:
       PH_FULL_ACTION: 1
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        python-version: ["pypy-3.8", "pypy-3.9", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["pypy-3.8", "pypy-3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Delay, waiting Pypi to update.
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["pypy-3.8", "pypy-3.9", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["pypy-3.8", "pypy-3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Delay, waiting Pypi to update.

--- a/.github/workflows/wheels-pi_heif.yml
+++ b/.github/workflows/wheels-pi_heif.yml
@@ -263,11 +263,13 @@ jobs:
         i: [
           { "docker_file": "manylinux_armv7l_wheels", "name": "manylinux" },
         ]
-        v: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        v: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - v: "3.10"
             i: { "docker_file": "musllinux_armv7l_wheels", "name": "musllinux" }
           - v: "3.11"
+            i: { "docker_file": "musllinux_armv7l_wheels", "name": "musllinux" }
+          - v: "3.12"
             i: { "docker_file": "musllinux_armv7l_wheels", "name": "musllinux" }
     env:
       KEY_HEAD: Pi-Heif-ARMv7l-${{ matrix.i['name'] }}

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ pillow_heif.register_avif_opener()
 | CPython 3.9        |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | CPython 3.10       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | CPython 3.11       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
+| CPython 3.12       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | PyPy 3.8 v7.3      |        ✅        |        N/A        |         ✅         |    N/A     |     ✅      |
 | PyPy 3.9 v7.3      |        ✅        |        N/A        |         ✅         |    N/A     |     ✅      |
 

--- a/pi-heif/README.md
+++ b/pi-heif/README.md
@@ -68,6 +68,7 @@ if pi_heif.is_supported("input.heic"):
 | CPython 3.9        |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | CPython 3.10       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | CPython 3.11       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
+| CPython 3.12       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | PyPy 3.8 v7.3      |        ✅        |        N/A        |         ✅         |    N/A     |     ✅      |
 | PyPy 3.9 v7.3      |        ✅        |        N/A        |         ✅         |    N/A     |     ✅      |
 

--- a/pi-heif/setup.cfg
+++ b/pi-heif/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: GNU General Public License v2 (GPLv2)


### PR DESCRIPTION

Changes proposed in this pull request:

 * Add Python 3.12 to the mix

The Python team encourages libraries to test against 3.12 now that beta is out
