### PR TITLE
min required Pillow from `8.4.0` to `9.1.1`

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install from source
         run: |
-          python3 -m pip install pillow==8.4.0
+          python3 -m pip install pillow==9.5.0
           python3 -m pip -v install ".[dev]"
 
       - name: LibHeif info
@@ -247,7 +247,7 @@ jobs:
 
       - name: Install from source
         run: |
-          sudo -H python3 -m pip install pillow==9.0.1 pytest defusedxml packaging numpy coverage
+          sudo -H python3 -m pip install pillow==9.3.0 pytest defusedxml packaging numpy coverage
           sudo -H PH_LIGHT_ACTION=1 python3 -m pip -v install --no-build-isolation .
 
       - name: LibHeif info

--- a/.github/workflows/test-src-build-linux.yml
+++ b/.github/workflows/test-src-build-linux.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["amd64", "arm64", "arm/v7"]
-        docker_file: ["Alpine_3_15", "Alpine_3_17", "Alpine_3_18", "Debian_11", "Debian_12", "Ubuntu_22_04"]
+        docker_file: ["Alpine_3_16", "Alpine_3_17", "Alpine_3_18", "Debian_11", "Debian_12", "Ubuntu_22_04"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-wheels-pi_heif.yml
+++ b/.github/workflows/test-wheels-pi_heif.yml
@@ -23,14 +23,14 @@ jobs:
           { "os": "debian", "ver": "11", "arch": "amd64" },
           { "os": "debian", "ver": "11", "arch": "arm64" },
           { "os": "debian", "ver": "11", "arch": "arm/v7" },
-          { "os": "alpine", "ver": "3.15", "arch": "amd64" },
-          { "os": "alpine", "ver": "3.15", "arch": "arm64" },
           { "os": "alpine", "ver": "3.16", "arch": "amd64" },
           { "os": "alpine", "ver": "3.16", "arch": "arm64" },
-          { "os": "alpine", "ver": "3.16", "arch": "arm/v7" },
           { "os": "alpine", "ver": "3.17", "arch": "amd64" },
           { "os": "alpine", "ver": "3.17", "arch": "arm64" },
           { "os": "alpine", "ver": "3.17", "arch": "arm/v7" },
+          { "os": "alpine", "ver": "3.18", "arch": "amd64" },
+          { "os": "alpine", "ver": "3.18", "arch": "arm64" },
+          { "os": "alpine", "ver": "3.18", "arch": "arm/v7" },
         ]
 
     steps:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -21,12 +21,12 @@ jobs:
           { "os": "debian", "ver": "10", "arch": "arm64" },
           { "os": "debian", "ver": "11", "arch": "amd64" },
           { "os": "debian", "ver": "11", "arch": "arm64" },
-          { "os": "alpine", "ver": "3.15", "arch": "amd64" },
-          { "os": "alpine", "ver": "3.15", "arch": "arm64" },
           { "os": "alpine", "ver": "3.16", "arch": "amd64" },
           { "os": "alpine", "ver": "3.16", "arch": "arm64" },
           { "os": "alpine", "ver": "3.17", "arch": "amd64" },
           { "os": "alpine", "ver": "3.17", "arch": "arm64" },
+          { "os": "alpine", "ver": "3.18", "arch": "amd64" },
+          { "os": "alpine", "ver": "3.18", "arch": "arm64" },
         ]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - The license for the project itself has been changed to "BSD-3-Clause" since "Apache 2.0" is not compatible with the "x265" encoder. #111
+- Minimum required `Pillow` version increased from `8.4.0` to `9.1.1`
 
 ## [0.12.0 - 2023-07-08]
 

--- a/docker/from_src/Alpine_3_16.Dockerfile
+++ b/docker/from_src/Alpine_3_16.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15 as base
+FROM alpine:3.16 as base
 
 RUN \
   apk add --no-cache \

--- a/pi-heif/setup.cfg
+++ b/pi-heif/setup.cfg
@@ -38,7 +38,7 @@ python_requires = >=3.7
 zip_safe = False
 packages = find:
 install_requires =
-    pillow>=8.4.0
+    pillow>=9.1.1
 
 [options.extras_require]
 tests-min =

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -58,7 +58,7 @@ class _LibHeifImageFile(ImageFile.ImageFile):
         if self._heif_file:
             frame_heif = self._heif_file[self.tell()]
             try:
-                if pil_version[:2] not in ("8.",) and pil_version[:4] not in ("9.0.", "9.1.", "9.2.", "9.3.", "9.4."):
+                if pil_version[:4] not in ("9.1.", "9.2.", "9.3.", "9.4."):
                     data = frame_heif.data
                 else:
                     data = bytes(frame_heif.data)

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -219,7 +219,7 @@ def _exif_from_pillow(img: Image.Image) -> Optional[bytes]:
     if "exif" in img.info:
         return img.info["exif"]
     if hasattr(img, "getexif"):
-        if pil_version[:2] not in ("8.",) and pil_version[:4] not in ("9.0.", "9.1."):
+        if pil_version[:4] not in ("9.1.",):
             exif = img.getexif()
             if exif:
                 return exif.tobytes()

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ python_requires = >=3.7
 zip_safe = False
 packages = find:
 install_requires =
-    pillow>=8.4.0
+    pillow>=9.1.1
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
Freed up the test matrix a little