### PR TITLE
CI clean up, more consistent logic

### DIFF
--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -20,7 +20,7 @@ jobs:
     needs: [pi_heif_build]
     if: "contains(github.event.head_commit.message, '[publish]')"
     name: Upload to PyPi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -46,13 +46,9 @@ jobs:
           name: wheels_pi_heif
           path: wheelhouse_pi_heif
 
-      - name: Install twine
-        run: |
-          python3 -m pip install twine
-          python3 -m pip install urllib3==1.26.15
-
       - name: Publish Pillow-Heif
         run: |
+          python3 -m pip install twine
           python3 -m twine upload --skip-existing wheelhouse_pillow_heif/*.whl
           python3 -m twine upload --skip-existing wheelhouse_pillow_heif/*tar.gz
         env:

--- a/.github/workflows/test-wheels-pi_heif.yml
+++ b/.github/workflows/test-wheels-pi_heif.yml
@@ -18,12 +18,12 @@ jobs:
           { "os": "oraclelinux", "ver": "9", "arch": "amd64" },
           { "os": "oraclelinux", "ver": "9", "arch": "arm64" },
           { "os": "fedora", "ver": "37", "arch": "amd64" },
-          { "os": "debian", "ver": "10", "arch": "amd64" },
-          { "os": "debian", "ver": "10", "arch": "arm64" },
-          { "os": "debian", "ver": "10", "arch": "arm/v7" },
           { "os": "debian", "ver": "11", "arch": "amd64" },
           { "os": "debian", "ver": "11", "arch": "arm64" },
           { "os": "debian", "ver": "11", "arch": "arm/v7" },
+          { "os": "debian", "ver": "12", "arch": "amd64" },
+          { "os": "debian", "ver": "12", "arch": "arm64" },
+          { "os": "debian", "ver": "12", "arch": "arm/v7" },
           { "os": "alpine", "ver": "3.16", "arch": "amd64" },
           { "os": "alpine", "ver": "3.16", "arch": "arm64" },
           { "os": "alpine", "ver": "3.17", "arch": "amd64" },
@@ -48,7 +48,7 @@ jobs:
         run: |
           echo PREPARE_CMD="apt update" >> $GITHUB_ENV
           echo INSTALL_CMD="apt install -y \
-            python3-minimal python3-distutils python3-pip python3-dev \
+            python3-minimal python3-distutils python3-pip python3-dev python3-venv \
             zlib1g-dev libjpeg62-turbo-dev liblcms2-dev libwebp-dev libfribidi-dev libharfbuzz-dev" >> $GITHUB_ENV
 
       - name: Preparing musli

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -18,10 +18,10 @@ jobs:
           { "os": "oraclelinux", "ver": "9", "arch": "amd64" },
           { "os": "oraclelinux", "ver": "9", "arch": "arm64" },
           { "os": "fedora", "ver": "37", "arch": "amd64" },
-          { "os": "debian", "ver": "10", "arch": "amd64" },
-          { "os": "debian", "ver": "10", "arch": "arm64" },
           { "os": "debian", "ver": "11", "arch": "amd64" },
           { "os": "debian", "ver": "11", "arch": "arm64" },
+          { "os": "debian", "ver": "12", "arch": "amd64" },
+          { "os": "debian", "ver": "12", "arch": "arm64" },
           { "os": "alpine", "ver": "3.16", "arch": "amd64" },
           { "os": "alpine", "ver": "3.16", "arch": "arm64" },
           { "os": "alpine", "ver": "3.17", "arch": "amd64" },
@@ -47,7 +47,7 @@ jobs:
         run: |
           echo PREPARE_CMD="apt update" >> $GITHUB_ENV
           echo INSTALL_CMD="apt install -y \
-            python3-minimal python3-distutils python3-pip python3-dev \
+            python3-minimal python3-distutils python3-pip python3-dev python3-venv \
             zlib1g-dev libjpeg62-turbo-dev liblcms2-dev libwebp-dev libfribidi-dev libharfbuzz-dev" >> $GITHUB_ENV
 
       - name: Preparing musli

--- a/.github/workflows/wheels-pi_heif.yml
+++ b/.github/workflows/wheels-pi_heif.yml
@@ -38,6 +38,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
       - name: Transform to Pi-Heif
         run: |
           cp -r -v -force ./pi-heif/* .
@@ -68,13 +71,12 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.12.3
+          python3 -m pip install cibuildwheel==2.14.1
           python3 -m cibuildwheel
         env:
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* pp39-*"
-          CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -vv -w {dest_dir} {wheel} --add-path ${{ env.MSYS2_PREFIX }}/bin"
+          CIBW_ARCHS: "AMD64"
           CIBW_ENVIRONMENT_WINDOWS: PH_LIGHT_ACTION=1 TEST_DECODE_THREADS=0
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -vv -w {dest_dir} {wheel} --add-path ${{ env.MSYS2_PREFIX }}/bin"
 
       - name: Checking built wheels
         run: |
@@ -101,10 +103,10 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.12.3
+          python3 -m pip install cibuildwheel==2.14.1
           python3 -m cibuildwheel
         env:
-          CIBW_BUILD: "*-macosx_x86_64"
+          CIBW_ARCHS: "x86_64"
           CIBW_ENVIRONMENT_MACOS: PH_LIGHT_ACTION=1 TEST_DECODE_THREADS=0
 
       - name: Checking built wheels
@@ -151,14 +153,10 @@ jobs:
           OS_PACKAGES: "fribidi-dev harfbuzz-dev jpeg-dev lcms2-dev openjpeg-dev"
 
       - name: 32-bit manylinux preparations
-        if: matrix.cibw_buildlinux == 'manylinux' && matrix.cibw_arch == 'i686'
+        if: matrix.cibw_buildlinux == 'manylinux'
         run: echo INSTALL_OS_PACKAGES="yum makecache && yum install -y $OS_PACKAGES" >> $GITHUB_ENV
         env:
           OS_PACKAGES: "libjpeg-turbo-devel lcms2-devel"
-
-      - name: Only minimal testing on aarch64
-        if: matrix.cibw_arch == 'aarch64'
-        run: echo CIBW_TEST_EXTRAS="tests-min" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         with:
@@ -170,7 +168,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.12.3
+          python3 -m pip install cibuildwheel==2.14.1
           python3 -m cibuildwheel
         env:
           CIBW_BUILD: ${{ format('cp3*-{0}_{1}', matrix.cibw_buildlinux, matrix.cibw_arch) }}
@@ -198,7 +196,7 @@ jobs:
       fail-fast: true
       matrix:
         cibw_buildlinux: [ manylinux ]
-        cibw_arch: [ "aarch64", "i686", "x86_64" ]
+        cibw_arch: [ "aarch64", "x86_64" ]
     name: ${{ matrix.cibw_buildlinux }} • ${{ matrix.cibw_arch }} • PyPy
     runs-on: ubuntu-20.04
     env:
@@ -218,10 +216,6 @@ jobs:
         with:
           platforms: arm64
 
-      - name: Only minimal testing on aarch64
-        if: matrix.cibw_arch == 'aarch64'
-        run: echo CIBW_TEST_EXTRAS="tests-min" >> $GITHUB_ENV
-
       - uses: actions/cache@v3
         with:
           path: ${{ env.BUILD_DIR }}
@@ -232,7 +226,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.12.3
+          python3 -m pip install cibuildwheel==2.14.1
           python3 -m cibuildwheel
         env:
           CIBW_BUILD: ${{ format('pp3*-{0}_{1}', matrix.cibw_buildlinux, matrix.cibw_arch) }}
@@ -263,13 +257,11 @@ jobs:
         i: [
           { "docker_file": "manylinux_armv7l_wheels", "name": "manylinux" },
         ]
-        v: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        v: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - v: "3.10"
             i: { "docker_file": "musllinux_armv7l_wheels", "name": "musllinux" }
           - v: "3.11"
-            i: { "docker_file": "musllinux_armv7l_wheels", "name": "musllinux" }
-          - v: "3.12"
             i: { "docker_file": "musllinux_armv7l_wheels", "name": "musllinux" }
     env:
       KEY_HEAD: Pi-Heif-ARMv7l-${{ matrix.i['name'] }}

--- a/.github/workflows/wheels-pillow_heif.yml
+++ b/.github/workflows/wheels-pillow_heif.yml
@@ -37,6 +37,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
       - uses: msys2/setup-msys2@v2
         with:
           location: C:/temp
@@ -64,13 +67,12 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.12.3
+          python3 -m pip install cibuildwheel==2.14.1
           python3 -m cibuildwheel
         env:
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* pp39-*"
-          CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -vv -w {dest_dir} {wheel} --add-path ${{ env.MSYS2_PREFIX }}/bin"
+          CIBW_ARCHS: "AMD64"
           CIBW_ENVIRONMENT_WINDOWS: PH_FULL_ACTION=1
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -vv -w {dest_dir} {wheel} --add-path ${{ env.MSYS2_PREFIX }}/bin"
 
       - name: Check built wheels
         run: |
@@ -92,10 +94,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.12.3
+          python3 -m pip install cibuildwheel==2.14.1
           python3 -m cibuildwheel
         env:
-          CIBW_BUILD: "*-macosx_x86_64"
+          CIBW_ARCHS: "x86_64"
           CIBW_ENVIRONMENT_MACOS: PH_FULL_ACTION=1 TEST_DECODE_THREADS=0
 
       - name: Check built wheels
@@ -136,9 +138,11 @@ jobs:
         env:
           OS_PACKAGES: "fribidi-dev harfbuzz-dev jpeg-dev lcms2-dev openjpeg-dev"
 
-      - name: Only minimal testing on aarch64
-        if: matrix.cibw_arch == 'aarch64'
-        run: echo CIBW_TEST_EXTRAS="tests-min" >> $GITHUB_ENV
+      - name: manylinux preparations
+        if: matrix.cibw_buildlinux == 'manylinux'
+        run: echo INSTALL_OS_PACKAGES="yum makecache && yum install -y $OS_PACKAGES" >> $GITHUB_ENV
+        env:
+          OS_PACKAGES: "libjpeg-turbo-devel lcms2-devel"
 
       - uses: actions/cache@v3
         with:
@@ -148,15 +152,24 @@ jobs:
           KEY_LINUX_LIBS: ${{ hashFiles('libheif/linux/**') }}
           KEY_C_BUILD: ${{ hashFiles('libheif/linux_*.py') }}-${{ hashFiles('libheif/setup.py') }}
 
+      - name: Full testing on x86_64
+        if: matrix.cibw_arch == 'x86_64'
+        run: echo PH_TESTS_NO_HEVC_ENC=0 >> $GITHUB_ENV
+
+      - name: Minimal testing on aarch64
+        if: matrix.cibw_arch == 'aarch64'
+        run: echo PH_TESTS_NO_HEVC_ENC=1 >> $GITHUB_ENV
+
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.12.3
+          python3 -m pip install cibuildwheel==2.14.1
           python3 -m cibuildwheel
         env:
           CIBW_BUILD: ${{ format('cp3*-{0}_{1}', matrix.cibw_buildlinux, matrix.cibw_arch) }}
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BEFORE_ALL_LINUX: ${{ env.INSTALL_OS_PACKAGES }}
           CIBW_ENVIRONMENT_LINUX: BUILD_DIR=/host${{ env.BUILD_DIR }} PH_FULL_ACTION=1
+          CIBW_ENVIRONMENT_PASS_LINUX: PH_TESTS_NO_HEVC_ENC
 
       - name: Checking built wheels
         run: |
@@ -193,10 +206,6 @@ jobs:
         with:
           platforms: arm64
 
-      - name: Only minimal testing on aarch64
-        if: matrix.cibw_arch == 'aarch64'
-        run: echo CIBW_TEST_EXTRAS="tests-min" >> $GITHUB_ENV
-
       - uses: actions/cache@v3
         with:
           path: ${{ env.BUILD_DIR }}
@@ -205,15 +214,24 @@ jobs:
           KEY_LINUX_LIBS: ${{ hashFiles('libheif/linux/**') }}
           KEY_C_BUILD: ${{ hashFiles('libheif/linux_*.py') }}-${{ hashFiles('libheif/setup.py') }}
 
+      - name: Full testing on x86_64
+        if: matrix.cibw_arch == 'x86_64'
+        run: echo PH_TESTS_NO_HEVC_ENC=0 >> $GITHUB_ENV
+
+      - name: Minimal testing on aarch64
+        if: matrix.cibw_arch == 'aarch64'
+        run: echo PH_TESTS_NO_HEVC_ENC=1 >> $GITHUB_ENV
+
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.12.3
+          python3 -m pip install cibuildwheel==2.14.1
           python3 -m cibuildwheel
         env:
           CIBW_BUILD: ${{ format('pp3*-{0}_{1}', matrix.cibw_buildlinux, matrix.cibw_arch) }}
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BEFORE_ALL_LINUX: "yum makecache && yum install -y libjpeg-turbo-devel lcms2-devel"
           CIBW_ENVIRONMENT_LINUX: BUILD_DIR=/host${{ env.BUILD_DIR }} PH_FULL_ACTION=1
+          CIBW_ENVIRONMENT_PASS_LINUX: PH_TESTS_NO_HEVC_ENC
 
       - name: Checking built wheels
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.13.0 - 2023-08-0x]
 
+### Added
+
+- `Python 3.12`, `PyPy 3.10` wheels
+
 ### Changed
 
 - The license for the project itself has been changed to "BSD-3-Clause" since "Apache 2.0" is not compatible with the "x265" encoder. #111
@@ -13,7 +17,7 @@ All notable changes to this project will be documented in this file.
 
 This release is fully compatible with previous versions.
 
-## Added
+### Added
 
 - (Heif) restored lost ability after `0.9.x` versions to open HDR images in 10/12 bit. #96
 
@@ -22,7 +26,7 @@ This release is fully compatible with previous versions.
 - `libde265`(HEIF decoder) updated from 1.0.11 to 1.0.12 version. [changelog](https://github.com/strukturag/libde265/releases/tag/v1.0.12)
 - `libheif` updated to `1.16.2`.
 
-## Fixed
+### Fixed
 
 - Building from source when using `apt-repository ppa:strukturag/libheif`
 - (Heif) `encode` function with `stride` argument correctly saves image.

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ pillow_heif.register_avif_opener()
 | CPython 3.10       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | CPython 3.11       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | CPython 3.12       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
-| PyPy 3.8 v7.3      |        ✅        |        N/A        |         ✅         |    N/A     |     ✅      |
-| PyPy 3.9 v7.3      |        ✅        |        N/A        |         ✅         |    N/A     |     ✅      |
+| PyPy 3.9 v7.3      |        ✅        |         ✅         |         ✅         |    N/A     |     ✅      |
+| PyPy 3.10 v7.3     |        ✅        |         ✅         |         ✅         |    N/A     |     ✅      |
 
 &ast; **x86_64**, **aarch64** wheels.
 
-`ARMv7l`, `PyPy` 32-bit wheels are published only for [pi-heif](https://pypi.org/project/pi-heif/) from `0.10.0` version.
+`i686`, `ARMv7l`, `PyPy` 32-bit wheels are published only for [pi-heif](https://pypi.org/project/pi-heif/) from `0.13.0` version.

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -7,10 +7,7 @@ wheel_macos_arm_task:
 
   env:
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
-    CIBW_SKIP: 'pp* cp36-* cp37-*'
-    CIBW_BUILD: '*-macosx_arm64'
     CIBW_ARCHS: arm64
-    CIBW_PLATFORM: macos
     CIBW_ENVIRONMENT: 'MACOSX_DEPLOYMENT_TARGET=12.0 PH_FULL_ACTION=1'
 
   install_pre_requirements_script:
@@ -19,7 +16,7 @@ wheel_macos_arm_task:
     - brew install python@3.10
     - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
   install_cibuildwheel_script:
-    - python3 -m pip install cibuildwheel==2.12.3
+    - python3 -m pip install cibuildwheel==2.14.1
   run_cibuildwheel_script:
     - python3 -m cibuildwheel
   wheels_artifacts:
@@ -34,10 +31,7 @@ wheel_pi_heif_macos_arm_task:
 
   env:
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
-    CIBW_SKIP: 'pp* cp36-* cp37-*'
-    CIBW_BUILD: '*-macosx_arm64'
     CIBW_ARCHS: arm64
-    CIBW_PLATFORM: macos
     CIBW_ENVIRONMENT: 'MACOSX_DEPLOYMENT_TARGET=12.0 PH_LIGHT_ACTION=1'
 
   install_pre_requirements_script:
@@ -46,7 +40,7 @@ wheel_pi_heif_macos_arm_task:
     - brew install python@3.10
     - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
   install_cibuildwheel_script:
-    - python3 -m pip install cibuildwheel==2.12.3
+    - python3 -m pip install cibuildwheel==2.14.1
   transform_to_pi_heif_script:
     - cp -r -v ./pi-heif/* .
     - python3 .github/transform_to-pi_heif.py

--- a/docker/from_src/Debian_12.Dockerfile
+++ b/docker/from_src/Debian_12.Dockerfile
@@ -1,13 +1,10 @@
-FROM debian:bullseye-slim as base
+FROM debian:bookworm-slim as base
 
 RUN \
   apt-get -qq update && \
   apt-get -y -q install \
     python3-pip \
-    libfribidi-dev \
-    libharfbuzz-dev \
-    libjpeg-dev \
-    liblcms2-dev \
+    python3-pillow \
     libffi-dev \
     libtool \
     git \
@@ -17,21 +14,15 @@ RUN \
     libde265-dev \
     libx265-dev
 
-RUN \
-  python3 -m pip install --upgrade pip
-
-RUN \
-  python3 -m pip install Pillow==9.2.0
-
 FROM base as build_test
 
 COPY . /pillow_heif
 
 RUN \
   if [ `getconf LONG_BIT` = 64 ]; then \
-    python3 -m pip install -v "pillow_heif/.[tests]"; \
+    python3 -m pip install -v --break-system-packages "pillow_heif/.[tests]"; \
   else \
-    python3 -m pip install -v "pillow_heif/.[tests-min]"; \
+    python3 -m pip install -v --break-system-packages "pillow_heif/.[tests-min]"; \
     export PH_TESTS_NO_HEVC_ENC=1; \
   fi && \
   echo "**** Build Done ****" && \

--- a/docker/test_wheels.Dockerfile
+++ b/docker/test_wheels.Dockerfile
@@ -6,17 +6,21 @@ RUN $PREPARE_CMD
 ARG INSTALL_CMD
 RUN $INSTALL_CMD
 
-RUN python3 -m pip install --upgrade pip || echo "pip upgrade failed"
-RUN python3 -m pip install --prefer-binary pillow
-RUN python3 -m pip install pytest numpy pympler defusedxml
-
-ARG EX_ARG
-RUN python3 -m pip install $EX_ARG --no-deps --only-binary=:all: pillow_heif
-
 COPY . /pillow_heif
 
+ARG EX_ARG
 ARG TEST_TYPE
-RUN $TEST_TYPE && \
-    python3 -m pytest -v pillow_heif/. && \
+
+RUN \
+    $TEST_TYPE && \
+    python3 -m venv --system-site-packages venv && \
+    . venv/bin/activate && \
+    python3 -m pip install --upgrade pip || echo "pip upgrade failed" && \
+    python3 -m pip install --prefer-binary pillow && \
+    python3 -m pip install pytest pympler defusedxml && \
+    python3 -m pip install --only-binary=:all: numpy || true && \
+    python3 -m pip install $EX_ARG --no-deps --only-binary=:all: pillow_heif && \
+    \
+    python3 -m pytest -v pillow_heif && \
     echo "**** Test Done ****" && \
     python3 -m pip show pillow_heif

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -4,7 +4,7 @@ from platform import machine
 from re import IGNORECASE, MULTILINE, match, search
 from subprocess import DEVNULL, PIPE, STDOUT, CalledProcessError, TimeoutExpired, run
 
-# 1
+# 0
 BUILD_DIR = environ.get("BUILD_DIR", "/tmp/ph_build_stuff")
 INSTALL_DIR_LIBS = environ.get("INSTALL_DIR_LIBS", "/usr")
 PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"

--- a/pi-heif/README.md
+++ b/pi-heif/README.md
@@ -68,8 +68,8 @@ if pi_heif.is_supported("input.heic"):
 | CPython 3.10       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | CPython 3.11       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
 | CPython 3.12       |        ✅        |         ✅         |         ✅         |     ✅      |     ✅      |
-| PyPy 3.8 v7.3      |        ✅        |        N/A        |         ✅         |    N/A     |     ✅      |
-| PyPy 3.9 v7.3      |        ✅        |        N/A        |         ✅         |    N/A     |     ✅      |
+| PyPy 3.9 v7.3      |        ✅        |         ✅         |         ✅         |    N/A     |     ✅      |
+| PyPy 3.10 v7.3     |        ✅        |         ✅         |         ✅         |    N/A     |     ✅      |
 
 &ast; **i686**, **x86_64**, **aarch64** wheels.
 

--- a/pillow_heif/_version.py
+++ b/pillow_heif/_version.py
@@ -1,3 +1,3 @@
 """ Version of pillow_heif"""
 
-__version__ = "0.12.0"
+__version__ = "0.13.0-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,11 +69,15 @@ messages_control.disable = [
 
 [tool.cibuildwheel]
 build-verbosity = "2"
+build = ["cp38-* cp39-* cp310-* cp311-* cp312-* pp39-* pp310-*"]
 skip = ["cp36-* cp37-* pp37-* pp38-*"]
-
-[tool.cibuildwheel.linux]
-test-extras = "tests"
+test-extras = "tests-min"
 test-command = "pytest {project}"
+before-test = [
+    "pip install --prefer-binary pillow",
+    "pip install --only-binary=:all: numpy || true",
+    "pip install pympler || true",
+]
 
 [tool.cibuildwheel.macos]
 before-all = [
@@ -87,14 +91,9 @@ repair-wheel-command = [
   "DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel}",
   "DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel -v --require-archs {delocate_archs} -w {dest_dir} {wheel}",
 ]
-test-extras = "tests"
-test-command = "pytest {project}"
 test-skip = "cp38-macosx_arm64"
 
 [tool.cibuildwheel.windows]
 before-build = [
     "pip install delvewheel",
-    "pip install --prefer-binary pillow",
 ]
-test-extras = "tests"
-test-command = "pytest {project}"


### PR DESCRIPTION
This will allow to build and publish Python3.12 and PyPy 3.10 wheels.
And from this point this CI will allow to build wheels for Python that are deprecated, and I do not need to rush to deprecate python in future .
Most build options are now in `pyproject.toml`
