### PR TITLE
linux: libaom-3.6.1 + musllinux_1_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1x.x - 2023-0x-xx]
 
+### Changed
+
+- Linux: `libaom` updated to `3.6.1`, `musllinux` builds switched to `musllinux_1_2` tag.
+
 ### Fixed
 
 - When building from source, the installer additionally searches for `libheif` using `pkg-config`. #128

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -10,7 +10,7 @@ INSTALL_DIR_LIBS = environ.get("INSTALL_DIR_LIBS", "/usr")
 PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"
 
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/get/0b75c44c10e605fe9e9ebed58f04a46271131827.tar.gz"
-LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.5.0.tar.gz"
+LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.6.1.tar.gz"
 LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.12/libde265-1.0.12.tar.gz"
 LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.16.2/libheif-1.16.2.tar.gz"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,3 +97,8 @@ test-skip = "cp38-macosx_arm64"
 before-build = [
     "pip install delvewheel",
 ]
+
+[tool.cibuildwheel.linux]
+musllinux-i686-image = "musllinux_1_2"
+musllinux-x86_64-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"


### PR DESCRIPTION
New musllinux image has fresh GCC version that can build last `libaom`.