### PR TITLE
fixed "heif_writer callback returned a null error text" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## [0.14.0 - 2023-11-xx]
+
+### Fixed
+
+- Support of libheif `1.17.0`. #156
+
 ## [0.13.1 - 2023-10-15]
 
 ### Added

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -8,7 +8,7 @@
 
 #define RETURN_NONE Py_INCREF(Py_None); return Py_None;
 
-static struct heif_error heif_error_no = { .code = 0, .subcode = 0, .message = NULL };
+static struct heif_error heif_error_no = { .code = 0, .subcode = 0, .message = "" };
 
 int check_error(struct heif_error error) {
     if (error.code == heif_error_Ok) {


### PR DESCRIPTION
Fixes:

```
/home/runner/work/pillow_heif/pillow_heif/tests/numpy_test.py:24: in <module>
    im_heif.save(heif_buf)
/home/runner/work/pillow_heif/pillow_heif/pillow_heif/heif.py:341: in save
    _encode_images(self._images, fp, **kwargs)
/home/runner/work/pillow_heif/pillow_heif/pillow_heif/heif.py:554: in _encode_images
    ctx_write.save(fp)
/home/runner/work/pillow_heif/pillow_heif/pillow_heif/misc.py:370: in save
    data = self.ctx_write.finalize()
E   ValueError: heif_writer callback returned a null error text
```
