### PR TITLE
reverted some changes from #158

### DIFF
--- a/.github/workflows/test-src-build-linux.yml
+++ b/.github/workflows/test-src-build-linux.yml
@@ -36,10 +36,12 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["amd64", "arm64"]
-        docker_file: ["Alpine_3_18", "Almalinux_9"]
+        docker_file: ["Alpine_3_17", "Alpine_3_18", "Almalinux_9", "Debian_12"]
         include:
           - arch: "arm/v7"
             docker_file: "Alpine_3_18"
+          - arch: "arm/v7"
+            docker_file: "Debian_12"
           - arch: "amd64"
             docker_file: "Fedora_38"
 

--- a/docker/from_src/Alpine_3_17.Dockerfile
+++ b/docker/from_src/Alpine_3_17.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 as base
+FROM alpine:3.17 as base
 
 RUN \
   apk add --no-cache \
@@ -9,7 +9,6 @@ RUN \
     nasm \
     aom-dev \
     x265-dev \
-    libde265-dev \
     py3-numpy \
     py3-pillow
 

--- a/docker/from_src/Debian_12.Dockerfile
+++ b/docker/from_src/Debian_12.Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:bookworm-slim as base
+
+RUN \
+  apt-get -qq update && \
+  apt-get -y -q install \
+    python3-pip \
+    python3-pillow \
+    libffi-dev \
+    libtool \
+    git \
+    cmake \
+    nasm \
+    wget \
+    libde265-dev \
+    libx265-dev \
+    libaom-dev
+
+FROM base as build_test
+
+COPY . /pillow_heif
+
+RUN \
+  python3 pillow_heif/libheif/linux_build_libs.py && \
+  if [ `getconf LONG_BIT` = 64 ]; then \
+    python3 -m pip install -v --break-system-packages "pillow_heif/.[tests]"; \
+  else \
+    python3 -m pip install -v --break-system-packages "pillow_heif/.[tests-min]"; \
+    export PH_TESTS_NO_HEVC_ENC=1; \
+  fi && \
+  echo "**** Build Done ****" && \
+  python3 -c "import pillow_heif; print(pillow_heif.libheif_info())" && \
+  pytest pillow_heif && \
+  echo "**** Test Done ****"


### PR DESCRIPTION
Next version:

LibHeif will be 1.17.3 version, as it does not present in Alpine repos and many other Linux repos, need return of checking installed libs to speed up CI.
In `build from src` actions all libraries except libheif will be installed from repos, and libheif will be build by `linux_build_libs.py` 

#158