### PR TITLE
Pi-Heif: Python3.12 32-bit `armv7` wheels

### DIFF
--- a/.github/workflows/wheels-pi_heif.yml
+++ b/.github/workflows/wheels-pi_heif.yml
@@ -260,11 +260,13 @@ jobs:
         i: [
           { "docker_file": "manylinux_armv7l_wheels", "name": "manylinux" },
         ]
-        v: ["3.8", "3.9", "3.10", "3.11"]
+        v: ["3.9", "3.10", "3.11", "3.12"]
         include:
           - v: "3.10"
             i: { "docker_file": "musllinux_armv7l_wheels", "name": "musllinux" }
           - v: "3.11"
+            i: { "docker_file": "musllinux_armv7l_wheels", "name": "musllinux" }
+          - v: "3.12"
             i: { "docker_file": "musllinux_armv7l_wheels", "name": "musllinux" }
     env:
       KEY_HEAD: Pi-Heif-ARMv7l-${{ matrix.i['name'] }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,19 @@ All notable changes to this project will be documented in this file.
 
 ## [0.14.0 - 2023-11-xx]
 
+### Added
+
+- Pi-Heif: Python3.12 32-bit `armv7` wheels. #160
+
 ### Changed
 
 - Minimum supported Pillow version raised to `9.2.0`.
 - Linux: When building from source, `libheif` and other libraries are no longer try built automatically. #158
+- Pi-Heif: As last libheif version `1.17.3` requires minimum `cmake>=3.16.3` dropped Debian `10 armv7` wheels. #160
 
 ### Fixed
 
-- Support of libheif `1.17.1`. #156
+- Support of libheif `1.17.x`. #156
 
 ## [0.13.1 - 2023-10-15]
 

--- a/docker/manylinux_armv7l_wheels.Dockerfile
+++ b/docker/manylinux_armv7l_wheels.Dockerfile
@@ -1,6 +1,6 @@
 ARG PY_VERSION
 
-FROM python:$PY_VERSION-buster
+FROM python:$PY_VERSION-bullseye
 
 COPY . /
 
@@ -38,7 +38,7 @@ RUN \
   echo "**** Repairing wheel ****" && \
   PTAG=$(echo $PY_VERSION | tr -d '.' | tr -d '"') && \
   python3 -m pip install auditwheel && \
-  python3 -m auditwheel repair -w repaired_dist/ dist_manylinux/*-cp$PTAG-*.whl --plat manylinux_2_28_armv7l && \
+  python3 -m auditwheel repair -w repaired_dist/ dist_manylinux/*-cp$PTAG-*.whl --plat manylinux_2_31_armv7l && \
   echo "**** Testing wheel ****" && \
   python3 -m pip install repaired_dist/*-cp$PTAG-*manylinux*.whl && \
   python3 -c "import pillow_heif; print(pillow_heif.libheif_info())" && \

--- a/docker/musllinux_armv7l_wheels.Dockerfile
+++ b/docker/musllinux_armv7l_wheels.Dockerfile
@@ -1,6 +1,6 @@
 ARG PY_VERSION
 
-FROM python:$PY_VERSION-alpine3.15
+FROM python:$PY_VERSION-alpine3.18
 
 COPY . /
 

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -212,7 +212,7 @@ def build_lib_linux(url: str, name: str):
 def build_libs() -> None:
     _original_dir = getcwd()
     try:
-        if not tool_check_version("cmake", "3.13.4"):
+        if not tool_check_version("cmake", "3.16.3"):
             raise ValueError("Can not find `cmake` with version >=3.16.3")
         if not is_library_installed("x265"):
             if not PH_LIGHT_VERSION:

--- a/pi-heif/README.md
+++ b/pi-heif/README.md
@@ -76,4 +76,4 @@ if pi_heif.is_supported("input.heic"):
 
 &ast; **i686**, **x86_64**, **aarch64** wheels.
 
-`ARMv7l`: wheels are present for Debian 10+(Ubuntu 20.04+) and Alpine 3.16/3.17
+`ARMv7l`: wheels are present for Debian 11+(Ubuntu 20.04+) and Alpine 3.16/3.17/3.18


### PR DESCRIPTION
For the new upcoming Alpine 3.19 and Ubuntu 24.04 LTS.

Last libheif requires `cmake>=3.16.3`, and it is takes too much time in CI to build cmake  from source, so Armv7 wheels for PiHeif will be build on Debian 11 instead of Debian 10.