### PR TITLE
Synonym for chroma encoder parameter: `subsampling`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Synonym for `chroma` encoder parameter: `subsampling`(usage is the same as in Pillow JPEG). #161
 - Pi-Heif: Python3.12 32-bit `armv7` wheels. #160
 
 ### Changed

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -307,6 +307,14 @@ class CtxEncode:
         self.ctx_write = _pillow_heif.CtxWrite(compression_format, -2 if quality is None else quality)
         enc_params = kwargs.get("enc_params", {})
         chroma = kwargs.get("chroma", None)
+        subsampling = kwargs.get("subsampling", None)
+        if chroma is None and subsampling:
+            subsampling_map = {
+                "4:4:4": 444,
+                "4:2:2": 422,
+                "4:2:0": 420,
+            }
+            chroma = subsampling_map.get(subsampling, None)
         if chroma:
             enc_params["chroma"] = chroma
         for key, value in enc_params.items():

--- a/tests/write_test.py
+++ b/tests/write_test.py
@@ -411,6 +411,14 @@ def test_chroma_heif_encoding_8bit(chroma, diff_epsilon, im):
     im_out = Image.open(im_buf)
     im = im.convert(mode=im_out.mode)
     helpers.assert_image_similar(im, im_out, diff_epsilon)
+    im_buf_subsampling = BytesIO()
+    subsampling_map = {
+        444: "4:4:4",
+        422: "4:2:2",
+        420: "4:2:0",
+    }
+    im.save(im_buf_subsampling, format="HEIF", quality=-1, subsampling=subsampling_map[chroma])
+    assert im_buf.getbuffer().nbytes == im_buf_subsampling.getbuffer().nbytes  # results should be the same
 
 
 @pytest.mark.parametrize("chroma, diff_epsilon", ((420, 1.83), (422, 1.32), (444, 0.99)))


### PR DESCRIPTION
This will be useful for those who are used to specifying subsampling as in Pillow for JPEG.

If both parameters are present, **chroma** parameter takes precedence.

_At first I wanted to remove the chroma parameter, but in libheif `subsampling` is called `chroma`, so I decided to do it the way I did, just add it as the synonym._