### PR TITLE
Update libheif to 1.17.3

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -135,6 +135,7 @@ jobs:
 
       - name: Install from source
         run: |
+          brew update && brew upgrade libheif
           python3 -m pip -v install ".[dev]"
 
       - name: LibHeif info
@@ -173,16 +174,10 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           location: C:/temp
+          update: true
           install: >-
             mingw-w64-x86_64-binutils
             mingw-w64-x86_64-libheif
-
-      - name: Build libheif and dependencies
-        shell: msys2 {0}
-        run: |
-          cd libheif/windows/mingw-w64-libheif
-          makepkg-mingw --syncdeps --noconfirm -f
-          pacman -U mingw-w64-x86_64-libheif-*-any.pkg.tar.zst --noconfirm
 
 #     In release or building from source we do not build `dav1d`,`rav1e` and `libSvtAv1Enc` libraries.
 #     Here we just test working with original package from MSYS.
@@ -198,9 +193,12 @@ jobs:
           cp ${{ env.MSYS2_PREFIX }}/bin/libgcc_s_seh-1.dll $site_packages/
           cp ${{ env.MSYS2_PREFIX }}/bin/libstdc++-6.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libsharpyuv-0.dll $site_packages/
-          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libdav1d.dll $site_packages/
+          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libdav1d-7.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/rav1e.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libSvtAv1Enc.dll $site_packages/
+          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libjpeg-8.dll $site_packages/
+          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libopenjp2-7.dll $site_packages/
+          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/zlib1.dll $site_packages/
 
       - name: Install from source
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Libheif updated from `1.16.2` to `1.17.3` version. #166
 - Minimum supported Pillow version raised to `9.2.0`.
 - Linux: When building from source, `libheif` and other libraries are no longer try built automatically. #158
 - Pi-Heif: As last libheif version `1.17.3` requires minimum `cmake>=3.16.3` dropped Debian `10 armv7` wheels. #160

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -5,8 +5,8 @@ Binary wheels combine several license-compatible libraries. Here they are listed
 Name: libheif
 License: LGPLv3
 Files: libheif.[dylib|so|dll]
-  For details, see https://github.com/strukturag/libheif/tree/v1.14.2/COPYING
-  Source code: https://github.com/strukturag/libheif/tree/v1.16.2
+  For details, see https://github.com/strukturag/libheif/tree/v1.17.3/COPYING
+  Source code: https://github.com/strukturag/libheif/tree/v1.17.3
 
 Name: libde265
 License: LGPLv3
@@ -23,5 +23,5 @@ Files: libx265.[dylib|so|dll]
 Name: libaom
 License: BSD 3-Clause
 Files: libaom.[dylib|so|dll]
-  For details, see https://aomedia.googlesource.com/aom/+/refs/tags/v3.5.0/LICENSE
-  Source code: https://aomedia.googlesource.com/aom/+/refs/tags/v3.5.0
+  For details, see https://aomedia.googlesource.com/aom/+/refs/tags/v3.6.1/LICENSE
+  Source code: https://aomedia.googlesource.com/aom/+/refs/tags/v3.6.1

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -14,7 +14,7 @@ PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/get/0b75c44c10e605fe9e9ebed58f04a46271131827.tar.gz"
 LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.6.1.tar.gz"
 LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.12/libde265-1.0.12.tar.gz"
-LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.16.2/libheif-1.16.2.tar.gz"
+LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.17.3/libheif-1.17.3.tar.gz"
 
 
 def download_file(url: str, out_path: str) -> bool:

--- a/libheif/macos/libheif.rb
+++ b/libheif/macos/libheif.rb
@@ -1,10 +1,10 @@
-# https://github.com/Homebrew/homebrew-core/blob/master/Formula/libheif.rb
+# https://github.com/Homebrew/homebrew-core/blob/master/Formula/lib/libheif.rb
 
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.16.2/libheif-1.16.2.tar.gz"
-  sha256 "7f97e4205c0bd9f9b8560536c8bd2e841d1c9a6d610401eb3eb87ed9cdfe78ea"
+  url "https://github.com/strukturag/libheif/releases/download/v1.17.3/libheif-1.17.3.tar.gz"
+  sha256 "8d5b6292e7931324f81f871f250ecbb9f874aa3c66b4f6f35ceb0bf3163b53ea"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10
@@ -25,6 +25,10 @@ class Libheif < Formula
       -DWITH_SvtEnc=OFF
       -DWITH_LIBSHARPYUV=OFF
       -DENABLE_PLUGIN_LOADING=OFF
+      -DWITH_JPEG_DECODER=OFF
+      -DWITH_JPEG_ENCODER=OFF
+      -DWITH_OpenJPEG_DECODER=OFF
+      -DWITH_OpenJPEG_ENCODER=OFF
       -DCMAKE_INSTALL_RPATH=#{rpath}
     ]
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args

--- a/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.16.2
-pkgrel=2
+pkgver=1.17.3
+pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-x265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('7f97e4205c0bd9f9b8560536c8bd2e841d1c9a6d610401eb3eb87ed9cdfe78ea')
+sha256sums=('8d5b6292e7931324f81f871f250ecbb9f874aa3c66b4f6f35ceb0bf3163b53ea')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
@@ -40,6 +40,10 @@ build() {
       -DWITH_SvtEnc=OFF \
       -DWITH_LIBSHARPYUV=OFF \
       -DENABLE_PLUGIN_LOADING=OFF \
+      -DWITH_JPEG_DECODER=OFF \
+      -DWITH_JPEG_ENCODER=OFF \
+      -DWITH_OpenJPEG_DECODER=OFF \
+      -DWITH_OpenJPEG_ENCODER=OFF \
       -DX265_CFLAGS="-DX265_API_IMPORTS" \
       ../${_realname}-${pkgver}
 

--- a/pi-heif/LICENSES_bundled.txt
+++ b/pi-heif/LICENSES_bundled.txt
@@ -5,8 +5,8 @@ Binary wheels combine several license-compatible libraries. Here they are listed
 Name: libheif
 License: LGPLv3
 Files: libheif.[dylib|so|dll]
-  For details, see https://github.com/strukturag/libheif/tree/v1.14.2/COPYING
-  Source code: https://github.com/strukturag/libheif/tree/v1.16.2
+  For details, see https://github.com/strukturag/libheif/tree/v1.17.3/COPYING
+  Source code: https://github.com/strukturag/libheif/tree/v1.17.3
 
 Name: libde265
 License: LGPLv3

--- a/pi-heif/libheif/macos/libheif.rb
+++ b/pi-heif/libheif/macos/libheif.rb
@@ -1,10 +1,10 @@
-# https://github.com/Homebrew/homebrew-core/blob/master/Formula/libheif.rb
+# https://github.com/Homebrew/homebrew-core/blob/master/Formula/lib/libheif.rb
 
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.16.2/libheif-1.16.2.tar.gz"
-  sha256 "7f97e4205c0bd9f9b8560536c8bd2e841d1c9a6d610401eb3eb87ed9cdfe78ea"
+  url "https://github.com/strukturag/libheif/releases/download/v1.17.3/libheif-1.17.3.tar.gz"
+  sha256 "8d5b6292e7931324f81f871f250ecbb9f874aa3c66b4f6f35ceb0bf3163b53ea"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10
@@ -22,6 +22,10 @@ class Libheif < Formula
       -DWITH_X265=OFF
       -DWITH_LIBSHARPYUV=OFF
       -DENABLE_PLUGIN_LOADING=OFF
+      -DWITH_JPEG_DECODER=OFF
+      -DWITH_JPEG_ENCODER=OFF
+      -DWITH_OpenJPEG_DECODER=OFF
+      -DWITH_OpenJPEG_ENCODER=OFF
       -DCMAKE_INSTALL_RPATH=#{rpath}
     ]
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args

--- a/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.16.2
-pkgrel=2
+pkgver=1.17.3
+pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('7f97e4205c0bd9f9b8560536c8bd2e841d1c9a6d610401eb3eb87ed9cdfe78ea')
+sha256sums=('8d5b6292e7931324f81f871f250ecbb9f874aa3c66b4f6f35ceb0bf3163b53ea')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
@@ -39,6 +39,10 @@ build() {
       -DWITH_SvtEnc=OFF \
       -DWITH_LIBSHARPYUV=OFF \
       -DENABLE_PLUGIN_LOADING=OFF \
+      -DWITH_JPEG_DECODER=OFF \
+      -DWITH_JPEG_ENCODER=OFF \
+      -DWITH_OpenJPEG_DECODER=OFF \
+      -DWITH_OpenJPEG_ENCODER=OFF \
       ../${_realname}-${pkgver}
 
   ${MINGW_PREFIX}/bin/cmake --build .

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -110,7 +110,7 @@ def test_full_build():
     info = pillow_heif.libheif_info()
     assert info["AVIF"]
     assert info["HEIF"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.16.2")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.3")
     if expected_version:
         assert info["libheif"] == expected_version
 
@@ -120,6 +120,6 @@ def test_light_build():
     info = pillow_heif.libheif_info()
     assert not info["AVIF"]
     assert not info["HEIF"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.16.2")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.3")
     if expected_version:
         assert info["libheif"] == expected_version


### PR DESCRIPTION
Changes proposed in this pull request:

 * Corrected `analysis-coverage` actions, use always last version of libheif from `brew`/`msys2`
 * Updated libheif from `1.16.2` to `1.17.3`

What is missing:
 * `ppa:strukturag/libheif` still is not updated and does not contain last libheif.

Partially related: #154