### PR TITLE
Passing `image_orientation` value to libheif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Synonym for `chroma` encoder parameter: `subsampling`(usage is the same as in Pillow JPEG). #161 #165
+- Passing `image_orientation` value to libheif, instead of manually rotating image according to EXIF before encoding. #168
 - Pi-Heif: Python3.12 32-bit `armv7` wheels. #160
 
 ### Changed

--- a/docs/workaround-orientation.rst
+++ b/docs/workaround-orientation.rst
@@ -34,6 +34,8 @@ but if there are two images and second does not have exif orientation tag, they 
 As we do not have an own soothsayer to say in which image editor will be image opened and
 will app rotate image or not based on Exif TAG, we comes to next chapter...
 
+*Updated(October 2023): last macOS Sonoma(14.0) changed it's behaviour and do not rotate `HEIF` images based on Exif TAG.*
+
 Q. So is there a decision?
 """"""""""""""""""""""""""
 
@@ -41,8 +43,11 @@ The best one and simplest solution is to
 `remove it <https://github.com/strukturag/libheif/issues/219#issuecomment-638110043>`_.
 
 So we set ``orientation`` to ``1`` in
-:py:meth:`~pillow_heif.HeifFile.add_from_pillow` (or during encoding `Pillow.Image`) to remove EXIF/XMP orientation tag
+:py:meth:`~pillow_heif.HeifFile.add_from_pillow` to remove EXIF/XMP orientation tag
 and rotate the image according to the removed tag.
+
+.. note:: *Updated(November 2023, pillow_heif>=1.14.0, PillowPlugin mode):
+    Image rotation value during encoding will be not removed from EXIF, and in addition will be set in HEIF header.*
 
 That allow us to properly handle situations when JPEG or PNG with orientation get encoded to HEIF.
 

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -44,10 +44,9 @@ int __PyDict_SetItemString(PyObject *p, const char *key, PyObject *val) {
     return r;
 }
 
-enum ph_image_type
-{
-  PhHeifImage = 0,
-  PhHeifDepthImage = 2,
+enum ph_image_type {
+    PhHeifImage = 0,
+    PhHeifDepthImage = 2,
 };
 
 /* =========== Objects ======== */
@@ -516,11 +515,11 @@ static PyObject* _CtxWriteImage_set_nclx_profile(CtxWriteImageObject* self, PyOb
 static PyObject* _CtxWriteImage_encode(CtxWriteImageObject* self, PyObject* args) {
     /* ctx: CtxWriteObject, primary: int */
     CtxWriteObject* ctx_write;
-    int primary, save_nclx;
+    int primary, save_nclx, image_orientation;
     struct heif_error error;
     struct heif_encoding_options* options;
 
-    if (!PyArg_ParseTuple(args, "Oii", (PyObject*)&ctx_write, &primary, &save_nclx))
+    if (!PyArg_ParseTuple(args, "Oiii", (PyObject*)&ctx_write, &primary, &save_nclx, &image_orientation))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
@@ -530,6 +529,7 @@ static PyObject* _CtxWriteImage_encode(CtxWriteImageObject* self, PyObject* args
         self->output_nclx_color_profile = heif_nclx_color_profile_alloc();
     if (self->output_nclx_color_profile)
         options->output_nclx_profile = self->output_nclx_color_profile;
+    options->image_orientation = image_orientation;
     error = heif_context_encode_image(ctx_write->ctx, self->image, ctx_write->encoder, options, &self->handle);
     heif_encoding_options_free(options);
     Py_END_ALLOW_THREADS
@@ -596,13 +596,14 @@ static PyObject* _CtxWriteImage_encode_thumbnail(CtxWriteImageObject* self, PyOb
     struct heif_image_handle* thumb_handle;
     struct heif_encoding_options* options;
     CtxWriteObject* ctx_write;
-    int thumb_box;
+    int thumb_box, image_orientation;
 
-    if (!PyArg_ParseTuple(args, "Oi", (PyObject*)&ctx_write, &thumb_box))
+    if (!PyArg_ParseTuple(args, "Oii", (PyObject*)&ctx_write, &thumb_box, &image_orientation))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
     options = heif_encoding_options_alloc();
+    options->image_orientation = image_orientation;
     error = heif_context_encode_thumbnail(
         ctx_write->ctx,
         self->image,

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -14,9 +14,9 @@ from .misc import (
     CtxEncode,
     _exif_from_pillow,
     _get_bytes,
+    _get_orientation_for_encoder,
     _get_primary_index,
     _pil_to_supported_mode,
-    _rotate_pil,
     _xmp_from_pillow,
     set_orientation,
 )
@@ -279,8 +279,5 @@ def _pil_encode_image(ctx: CtxEncode, img: Image.Image, primary: bool, **kwargs)
     if primary:
         _info.update(**kwargs)
     _info["primary"] = primary
-    original_orientation = set_orientation(_info)
     _img = _pil_to_supported_mode(img)
-    if original_orientation is not None and original_orientation != 1:
-        _img = _rotate_pil(_img, original_orientation)
-    ctx.add_image(_img.size, _img.mode, _img.tobytes(), **_info)
+    ctx.add_image(_img.size, _img.mode, _img.tobytes(), image_orientation=_get_orientation_for_encoder(_info), **_info)

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -14,6 +14,7 @@ from .misc import (
     MimCImage,
     _exif_from_pillow,
     _get_bytes,
+    _get_orientation_for_encoder,
     _get_primary_index,
     _pil_to_supported_mode,
     _retrieve_exif,
@@ -552,7 +553,14 @@ def _encode_images(images: List[HeifImage], fp, **kwargs) -> None:
             _info.update(**kwargs)
             _info["primary"] = True
         _info.pop("stride", 0)
-        ctx_write.add_image(img.size, img.mode, img.data, **_info, stride=img.stride)
+        ctx_write.add_image(
+            img.size,
+            img.mode,
+            img.data,
+            image_orientation=_get_orientation_for_encoder(_info),
+            **_info,
+            stride=img.stride,
+        )
     ctx_write.save(fp)
 
 


### PR DESCRIPTION
**Changes concern only image encoding**

Changes proposed in this pull request:

 * Removed rotation of image before encoding.
 * We add a parameter in the C module "image_orientation" that passes the orientation of the image to the libheif that should be recorded.
 
Orientation is taken from the same place(EXIF or XMP), so it should not be a big breaking change, in most(all?) cases results should be the same.
