### PR TITLE
Way to easy specify NCLX output color profile

### DIFF
--- a/.github/workflows/test-src-build-linux.yml
+++ b/.github/workflows/test-src-build-linux.yml
@@ -43,7 +43,7 @@ jobs:
           - arch: "arm/v7"
             docker_file: "Debian_12"
           - arch: "amd64"
-            docker_file: "Fedora_38"
+            docker_file: "Fedora_39"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Libheif updated from `1.16.2` to `1.17.3` version. #166
+- `NCLX` color profile - was reworked, updated docs, see PR for more info. #171
 - Minimum supported Pillow version raised to `9.2.0`.
 - Linux: When building from source, `libheif` and other libraries are no longer try built automatically. #158
 - Pi-Heif: As last libheif version `1.17.3` requires minimum `cmake>=3.16.3` dropped Debian `10 armv7` wheels. #160

--- a/docker/from_src/Fedora_39.Dockerfile
+++ b/docker/from_src/Fedora_39.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38 as base
+FROM fedora:39 as base
 
 RUN \
   dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm && \

--- a/docs/saving-images.rst
+++ b/docs/saving-images.rst
@@ -98,4 +98,66 @@ Method ``save`` supports ``primary_index`` parameter, that accepts ``index of im
 
 Specifying ``primary_index`` during ``save`` has highest priority.
 
+NCLX color profile
+""""""""""""""""""
+
+By default, since version **0.14.0**, if the image already had an NCLX color profile, it will be saved during encoding.
+
+.. note:: If you need old behaviour and for some reason do not need `NCLX` profile be saved you can set global option ``SAVE_NCLX_PROFILE`` to ``False``.
+
+To change it, you can specify your values for NCLX color conversion for ``save`` operation in two ways.
+
+Set `output` NCLX profile:
+
+    .. note:: Avalaible only from **0.14.0** version.
+
+    .. code-block:: python
+
+        buf = BytesIO()
+        im.save(buf, format="HEIF", matrix_coefficients=0, color_primaries=1)
+
+    In this case the default output NCLX profile will be created, and values you provide in such way,
+    will replace the values from default output profile.
+
+Edit NCLX profile in `image.info`:
+
+    .. code-block:: python
+
+        buf = BytesIO()
+        im.info["nclx_profile"]["matrix_coefficients"] = 0  # code assumes that image has already "nclx_profile"
+        im.info["nclx_profile"]["color_primaries"] = 0
+        im.save(buf, format="HEIF")
+
+    Under the hood it is much complex, as second way will change the **input** NCLX profile.
+
+The preferable way is to specify new NCLX values during ``save``.
+
+Here is additional info, from the **libheif repo** with relevant information:
+
+https://github.com/strukturag/libheif/discussions/931
+https://github.com/strukturag/libheif/issues/995
+
+Lossless encoding
+"""""""""""""""""
+
+.. note:: Parameter ``matrix_coefficients`` avalaible only from **0.14.0** version.
+
+Although the HEIF format is not intended for lossless encoding, it is possible with some encoders that support it.
+
+You need to specify ``matrix_coefficients=0``
+(which will tell **libheif** to perform the conversion in the RGB color space) and chrome subsampling equal to "4:4:4".
+
+.. code-block:: python
+
+    im_rgb = Image.merge(
+        "RGB",
+        [
+            Image.linear_gradient(mode="L"),
+            Image.linear_gradient(mode="L").transpose(Image.ROTATE_90),
+            Image.linear_gradient(mode="L").transpose(Image.ROTATE_180),
+        ],
+    )
+    buf = BytesIO()
+    im_rgb.save(buf, format="HEIF", quality=-1, chroma=444, matrix_coefficients=0)
+
 That's all.

--- a/docs/saving-images.rst
+++ b/docs/saving-images.rst
@@ -125,7 +125,7 @@ Edit NCLX profile in `image.info`:
 
         buf = BytesIO()
         im.info["nclx_profile"]["matrix_coefficients"] = 0  # code assumes that image has already "nclx_profile"
-        im.info["nclx_profile"]["color_primaries"] = 0
+        im.info["nclx_profile"]["color_primaries"] = 1
         im.save(buf, format="HEIF")
 
     Under the hood it is much complex, as second way will change the **input** NCLX profile.

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -339,6 +339,14 @@ class HeifFile:
 
             ``save_nclx_profile`` - boolean, see :py:attr:`~pillow_heif.options.SAVE_NCLX_PROFILE`
 
+            ``matrix_coefficients`` - int, nclx profile: color conversion matrix coefficients, default=6 (see h.273)
+
+            ``color_primaries`` - int, nclx profile: color primaries (see h.273)
+
+            ``transfer_characteristic`` - int, nclx profile: transfer characteristics (see h.273)
+
+            ``full_range_flag`` - nclx profile: full range flag, default: 1
+
         :param fp: A filename (string), pathlib.Path object or an object with `write` method.
         """
         _encode_images(self._images, fp, **kwargs)

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -368,14 +368,14 @@ class CtxEncode:
         self._finish_add_image(im_out, img.size, **kwargs)
 
     def _finish_add_image(self, im_out, size: tuple, **kwargs):
-        # color profile
+        # set ICC color profile
         __icc_profile = kwargs.get("icc_profile", None)
         if __icc_profile is not None:
             im_out.set_icc_profile(kwargs.get("icc_profile_type", "prof"), __icc_profile)
-        elif kwargs.get("nclx_profile", None):
-            nclx_profile = kwargs["nclx_profile"]
+        # set NCLX color profile
+        if kwargs.get("nclx_profile", None):
             im_out.set_nclx_profile(*[
-                nclx_profile[i]
+                kwargs["nclx_profile"][i]
                 for i in ("color_primaries", "transfer_characteristics", "matrix_coefficients", "full_range_flag")
             ])
         # encode
@@ -384,6 +384,10 @@ class CtxEncode:
             self.ctx_write,
             kwargs.get("primary", False),
             kwargs.get("save_nclx_profile", options.SAVE_NCLX_PROFILE),
+            kwargs.get("color_primaries", -1),
+            kwargs.get("transfer_characteristics", -1),
+            kwargs.get("matrix_coefficients", -1),
+            kwargs.get("full_range_flag", -1),
             image_orientation,
         )
         # adding metadata

--- a/pillow_heif/options.py
+++ b/pillow_heif/options.py
@@ -47,14 +47,13 @@ To learn more read: `here <https://github.com/strukturag/libheif/issues/784>`_
 When use pillow_heif as a plugin you can set it with: `register_*_opener(allow_incorrect_headers=True)`"""
 
 
-SAVE_NCLX_PROFILE = False
+SAVE_NCLX_PROFILE = True
 """Should be ``nclx`` profile saved or not.
 
-Default for all previous versions was NOT TO save `nclx` profile,
+Default for all previous versions(pillow_heif<0.14.0) was NOT TO save `nclx` profile,
 due to an old bug in Apple software refusing to open images with `nclx` profiles.
 Apple has already fixed this and there is no longer a need to not save the default profile.
-Currently to be compatible in behaviour with previous versions, still is ``False`` by default.
 
 .. note:: `save_nclx_profile` specified during calling ``save`` has higher priority than this.
 
-When use pillow_heif as a plugin you can unset it with: `register_*_opener(save_nclx_profile=True)`"""
+When use pillow_heif as a plugin you can unset it with: `register_*_opener(save_nclx_profile=False)`"""

--- a/tests/leaks_test.py
+++ b/tests/leaks_test.py
@@ -88,12 +88,12 @@ def test_open_to_numpy_mem_leaks():
 def test_color_profile_leaks(im, cp_type):
     mem_limit = None
     heif_file = pillow_heif.open_heif(Path(im), convert_hdr_to_8bit=False)
-    for i in range(1000):
+    for i in range(1200):
         _nclx = heif_file[0]._c_image.color_profile  # noqa
         _nclx = None  # noqa
         gc.collect()
         mem = _get_mem_usage()
-        if i < 100:
+        if i < 200:
             mem_limit = mem + 2
             continue
         assert mem <= mem_limit, f"memory usage limit exceeded after {i + 1} iterations. Color profile type:{cp_type}"

--- a/tests/options_test.py
+++ b/tests/options_test.py
@@ -33,21 +33,21 @@ def test_options_change_from_plugin_registering(register_opener):
             save_to_12bit=True,
             decode_threads=3,
             depth_images=False,
-            save_nclx_profile=True,
+            save_nclx_profile=False,
         )
         assert not options.THUMBNAILS
         assert options.QUALITY == 69
         assert options.SAVE_HDR_TO_12_BIT
         assert options.DECODE_THREADS == 3
         assert options.DEPTH_IMAGES is False
-        assert options.SAVE_NCLX_PROFILE is True
+        assert options.SAVE_NCLX_PROFILE is False
     finally:
         options.THUMBNAILS = True
         options.QUALITY = None
         options.SAVE_HDR_TO_12_BIT = False
         options.DECODE_THREADS = 4
         options.DEPTH_IMAGES = True
-        options.SAVE_NCLX_PROFILE = False
+        options.SAVE_NCLX_PROFILE = True
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="No HEVC encoder.")


### PR DESCRIPTION
This PR provides a way to easy specify NCLX output color profile.

Changes proposed in this pull request:

 * Image write tests were disabled if libheif has lower version then `1.17.3` _(libheif has some bug in 1.16.x versions, that crashes the process in some cases when NCLX writing is enabled)_
 * `SAVE_NCLX_PROFILE` changed to be `True` by default.
 * `color_primaries`, `transfer_characteristics`, `matrix_coefficients`, `full_range_flag` - can be specified as a parameters for ``save`` operation.

This approach allow easy to encode in lossless mode:

```python3

    buf = BytesIO()
    im_rgb.save(buf, format=save_format, quality=-1, chroma=444, matrix_coefficients=0)
    helpers.assert_image_equal(im_rgb, Image.open(buf))
```

Also it allows like before just change `nclx` values in `info` dictionary:

```python3

    buf = BytesIO()
    im.info["nclx_profile"]["matrix_coefficients"] = 0
    im.info["nclx_profile"]["color_primaries"] = 1
    im.save(buf, format="HEIF")

```

The documentation has been updated with this information, in theory that's it, **the problem with NCLX color profiles is solved and closed**.

https://github.com/strukturag/libheif/issues/995