### PR TITLE
updated libde265 to 1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 All notable changes to this project will be documented in this file.
 
-## [0.14.0 - 2023-11-xx]
+## [0.14.0 - 2023-12-0x]
 
 ### Added
 
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Minimum supported Pillow version raised to `9.2.0`.
 - Linux: When building from source, `libheif` and other libraries are no longer try built automatically. #158
 - Pi-Heif: As last libheif version `1.17.3` requires minimum `cmake>=3.16.3` dropped Debian `10 armv7` wheels. #160
+- libde265 updated from `1.0.12` to `1.0.13`. [changelog](https://github.com/strukturag/libde265/releases/tag/v1.0.13)
 
 ### Fixed
 

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -13,7 +13,7 @@ PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"
 
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/get/0b75c44c10e605fe9e9ebed58f04a46271131827.tar.gz"
 LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.6.1.tar.gz"
-LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.12/libde265-1.0.12.tar.gz"
+LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.13/libde265-1.0.13.tar.gz"
 LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.17.3/libheif-1.17.3.tar.gz"
 
 


### PR DESCRIPTION
HEIF decoder: **bugfixes/security fixes** 

[libde265 changelog](https://github.com/strukturag/libde265/releases/tag/v1.0.13)