### PR TITLE
updated libheif to 1.17.5

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -135,7 +135,6 @@ jobs:
 
       - name: Install from source
         run: |
-          brew update && brew upgrade libheif
           python3 -m pip -v install ".[dev]"
 
       - name: LibHeif info

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -135,6 +135,7 @@ jobs:
 
       - name: Install from source
         run: |
+          brew update && brew upgrade libheif
           python3 -m pip -v install ".[dev]"
 
       - name: LibHeif info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Libheif updated from `1.16.2` to `1.17.4` version. #166 #175
+- Libheif updated from `1.16.2` to `1.17.5` version. #166 #175
 - `NCLX` color profile - was reworked, updated docs, see PR for more info. #171
 - Minimum supported Pillow version raised to `9.2.0`.
 - Linux: When building from source, `libheif` and other libraries are no longer try built automatically. #158
 - Pi-Heif: As last libheif version requires minimum `cmake>=3.16.3` dropped Debian `10 armv7` wheels. #160
-- libde265 updated from `1.0.12` to `1.0.13`. [changelog](https://github.com/strukturag/libde265/releases/tag/v1.0.13)
+- libde265 updated from `1.0.12` to `1.0.14`. [changelog](https://github.com/strukturag/libde265/releases/tag/v1.0.13)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Libheif updated from `1.16.2` to `1.17.3` version. #166
+- Libheif updated from `1.16.2` to `1.17.4` version. #166 #175
 - `NCLX` color profile - was reworked, updated docs, see PR for more info. #171
 - Minimum supported Pillow version raised to `9.2.0`.
 - Linux: When building from source, `libheif` and other libraries are no longer try built automatically. #158
-- Pi-Heif: As last libheif version `1.17.3` requires minimum `cmake>=3.16.3` dropped Debian `10 armv7` wheels. #160
+- Pi-Heif: As last libheif version requires minimum `cmake>=3.16.3` dropped Debian `10 armv7` wheels. #160
 - libde265 updated from `1.0.12` to `1.0.13`. [changelog](https://github.com/strukturag/libde265/releases/tag/v1.0.13)
 
 ### Fixed

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -13,8 +13,8 @@ PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"
 
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/get/0b75c44c10e605fe9e9ebed58f04a46271131827.tar.gz"
 LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.6.1.tar.gz"
-LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.13/libde265-1.0.13.tar.gz"
-LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.17.4/libheif-1.17.4.tar.gz"
+LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.14/libde265-1.0.14.tar.gz"
+LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.17.5/libheif-1.17.5.tar.gz"
 
 
 def download_file(url: str, out_path: str) -> bool:

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -14,7 +14,7 @@ PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/get/0b75c44c10e605fe9e9ebed58f04a46271131827.tar.gz"
 LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.6.1.tar.gz"
 LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.13/libde265-1.0.13.tar.gz"
-LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.17.3/libheif-1.17.3.tar.gz"
+LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.17.4/libheif-1.17.4.tar.gz"
 
 
 def download_file(url: str, out_path: str) -> bool:

--- a/libheif/macos/libheif.rb
+++ b/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.17.3/libheif-1.17.3.tar.gz"
-  sha256 "8d5b6292e7931324f81f871f250ecbb9f874aa3c66b4f6f35ceb0bf3163b53ea"
+  url "https://github.com/strukturag/libheif/releases/download/v1.17.4/libheif-1.17.4.tar.gz"
+  sha256 "3619c092992eb5ccaf7795cbdc8ac70f96ab0f20fc5681fcef6ff5fec027a838"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10

--- a/libheif/macos/libheif.rb
+++ b/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.17.4/libheif-1.17.4.tar.gz"
-  sha256 "3619c092992eb5ccaf7795cbdc8ac70f96ab0f20fc5681fcef6ff5fec027a838"
+  url "https://github.com/strukturag/libheif/releases/download/v1.17.5/libheif-1.17.5.tar.gz"
+  sha256 "38ab01938ef419dbebb98346dc0b1c8bb503a0449ea61a0e409a988786c2af5b"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10

--- a/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.17.3
+pkgver=1.17.4
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-x265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8d5b6292e7931324f81f871f250ecbb9f874aa3c66b4f6f35ceb0bf3163b53ea')
+sha256sums=('3619c092992eb5ccaf7795cbdc8ac70f96ab0f20fc5681fcef6ff5fec027a838')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.17.4
+pkgver=1.17.5
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-x265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('3619c092992eb5ccaf7795cbdc8ac70f96ab0f20fc5681fcef6ff5fec027a838')
+sha256sums=('38ab01938ef419dbebb98346dc0b1c8bb503a0449ea61a0e409a988786c2af5b')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/pi-heif/libheif/macos/libheif.rb
+++ b/pi-heif/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.17.3/libheif-1.17.3.tar.gz"
-  sha256 "8d5b6292e7931324f81f871f250ecbb9f874aa3c66b4f6f35ceb0bf3163b53ea"
+  url "https://github.com/strukturag/libheif/releases/download/v1.17.4/libheif-1.17.4.tar.gz"
+  sha256 "3619c092992eb5ccaf7795cbdc8ac70f96ab0f20fc5681fcef6ff5fec027a838"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10

--- a/pi-heif/libheif/macos/libheif.rb
+++ b/pi-heif/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.17.4/libheif-1.17.4.tar.gz"
-  sha256 "3619c092992eb5ccaf7795cbdc8ac70f96ab0f20fc5681fcef6ff5fec027a838"
+  url "https://github.com/strukturag/libheif/releases/download/v1.17.5/libheif-1.17.5.tar.gz"
+  sha256 "38ab01938ef419dbebb98346dc0b1c8bb503a0449ea61a0e409a988786c2af5b"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10

--- a/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.17.3
+pkgver=1.17.4
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8d5b6292e7931324f81f871f250ecbb9f874aa3c66b4f6f35ceb0bf3163b53ea')
+sha256sums=('3619c092992eb5ccaf7795cbdc8ac70f96ab0f20fc5681fcef6ff5fec027a838')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.17.4
+pkgver=1.17.5
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('3619c092992eb5ccaf7795cbdc8ac70f96ab0f20fc5681fcef6ff5fec027a838')
+sha256sums=('38ab01938ef419dbebb98346dc0b1c8bb503a0449ea61a0e409a988786c2af5b')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -25,6 +25,7 @@ def test_libheif_info():
         "1.17.1",
         "1.17.3",
         "1.17.4",
+        "1.17.5",
     )
 
 
@@ -110,7 +111,7 @@ def test_full_build():
     info = pillow_heif.libheif_info()
     assert info["AVIF"]
     assert info["HEIF"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.4")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.5")
     if expected_version:
         assert info["libheif"] == expected_version
 
@@ -120,6 +121,6 @@ def test_light_build():
     info = pillow_heif.libheif_info()
     assert not info["AVIF"]
     assert not info["HEIF"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.4")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.5")
     if expected_version:
         assert info["libheif"] == expected_version

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -16,7 +16,6 @@ def test_libheif_info():
     for key in ("HEIF", "AVIF"):
         assert key in info
     assert pillow_heif.libheif_version() in (
-        "1.14.0",
         "1.14.1",
         "1.14.2",
         "1.15.1",
@@ -25,6 +24,7 @@ def test_libheif_info():
         "1.16.2",
         "1.17.1",
         "1.17.3",
+        "1.17.4",
     )
 
 
@@ -110,7 +110,7 @@ def test_full_build():
     info = pillow_heif.libheif_info()
     assert info["AVIF"]
     assert info["HEIF"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.3")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.4")
     if expected_version:
         assert info["libheif"] == expected_version
 
@@ -120,6 +120,6 @@ def test_light_build():
     info = pillow_heif.libheif_info()
     assert not info["AVIF"]
     assert not info["HEIF"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.3")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.4")
     if expected_version:
         assert info["libheif"] == expected_version


### PR DESCRIPTION
For standard use of Pillow-Heif, only the second fix is important, libheif now has much better support for AVIF image encoding.
_Anyway we want to the last libheif be in wheels in the upcoming release._

Fixes:

 * ispe boxes in AVIF images with clap boxes were written with the wrong size (would only happen with svt-av1 encoder),
 * always output MIAF brand for AVIF images
 * fix kvazaar encoding with odd image sizes and encodings with non-4:2:0 chroma
