### PR TITLE
libheif_info: Extended the returning results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 
-## [0.1x.x - 2024-0x-xx]
+## [0.15.0 - 2024-01-xx]
+
+### Added
+
+- `libheif_info` function: added `encoders` and `decoders` keys to the result, for future libheif plugins support. #189
 
 ### Changed
 

--- a/pillow_heif/_lib_info.py
+++ b/pillow_heif/_lib_info.py
@@ -1,5 +1,7 @@
 """Functions to get versions of underlying libraries."""
 
+import typing
+
 try:
     import _pillow_heif
 except ImportError as ex:
@@ -10,18 +12,27 @@ except ImportError as ex:
 
 def libheif_version() -> str:
     """Returns ``libheif`` version."""
-    return _pillow_heif.lib_info["libheif"]
+    return _pillow_heif.get_lib_info()["libheif"]
 
 
-def libheif_info() -> dict:
+def libheif_info() -> dict[str, typing.Union[str, dict[str, str]]]:
     """Returns a dictionary with version information.
 
-    The keys `libheif`, `HEIF`, `AVIF` are always present, but values for `HEIF`/`AVIF` can be empty.
+    The keys `libheif`, `HEIF`, `AVIF`, `encoders`, `decoders` are always present, but values for all except
+    `libheif` can be empty.
 
     {
-        'libheif': '1.14.2',
+        'libheif': '1.15.2',
         'HEIF': 'x265 HEVC encoder (3.4+31-6722fce1f)',
-        'AVIF': 'AOMedia Project AV1 Encoder 3.5.0'
+        'AVIF': 'AOMedia Project AV1 Encoder 3.5.0',
+        'encoders': {
+            'encoder1_id': 'encoder1_full_name',
+            'encoder2_id': 'encoder2_full_name',
+        },
+        'decoders': {
+            'decoder1_id': 'decoder1_full_name',
+            'decoder2_id': 'decoder2_full_name',
+        },
     }
     """
-    return _pillow_heif.lib_info
+    return _pillow_heif.get_lib_info()

--- a/pillow_heif/_version.py
+++ b/pillow_heif/_version.py
@@ -1,3 +1,3 @@
 """Version of pillow_heif/pi_heif."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0.dev0"

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -175,7 +175,7 @@ def register_heif_opener(**kwargs) -> None:
     """
     __options_update(**kwargs)
     Image.register_open(HeifImageFile.format, HeifImageFile, _is_supported_heif)
-    if _pillow_heif.lib_info["HEIF"]:
+    if _pillow_heif.get_lib_info()["HEIF"]:
         Image.register_save(HeifImageFile.format, _save_heif)
         Image.register_save_all(HeifImageFile.format, _save_all_heif)
     extensions = [".heic", ".heics", ".heif", ".heifs", ".hif"]
@@ -216,7 +216,7 @@ def register_avif_opener(**kwargs) -> None:
 
     :param kwargs: dictionary with values to set in options. See: :ref:`options`.
     """
-    if not _pillow_heif.lib_info["AVIF"]:
+    if not _pillow_heif.get_lib_info()["AVIF"]:
         warn("This version of `pillow-heif` was built without AVIF support.", stacklevel=1)
         return
     __options_update(**kwargs)

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -544,7 +544,7 @@ def encode(mode: str, size: tuple, data, fp, **kwargs) -> None:
 def _encode_images(images: List[HeifImage], fp, **kwargs) -> None:
     compression = kwargs.get("format", "HEIF")
     compression_format = HeifCompressionFormat.AV1 if compression == "AVIF" else HeifCompressionFormat.HEVC
-    if not _pillow_heif.lib_info[compression]:
+    if not _pillow_heif.get_lib_info()[compression]:
         raise RuntimeError(f"No {compression} encoder found.")
     images_to_save: List[HeifImage] = images + kwargs.get("append_images", [])
     if not kwargs.get("save_all", True):

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -13,11 +13,9 @@ os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 def test_libheif_info():
     info = pillow_heif.libheif_info()
-    for key in ("HEIF", "AVIF"):
+    for key in ("HEIF", "AVIF", "encoders", "decoders"):
         assert key in info
     assert pillow_heif.libheif_version() in (
-        "1.14.1",
-        "1.14.2",
         "1.15.1",
         "1.15.2",
         "1.16.1",
@@ -112,6 +110,8 @@ def test_full_build():
     info = pillow_heif.libheif_info()
     assert info["AVIF"]
     assert info["HEIF"]
+    assert info["encoders"]
+    assert info["decoders"]
     expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.6")
     if expected_version:
         assert info["libheif"] == expected_version
@@ -122,6 +122,7 @@ def test_light_build():
     info = pillow_heif.libheif_info()
     assert not info["AVIF"]
     assert not info["HEIF"]
+    assert info["decoders"]
     expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.6")
     if expected_version:
         assert info["libheif"] == expected_version

--- a/tests/write_test.py
+++ b/tests/write_test.py
@@ -98,7 +98,10 @@ def test_pillow_save_one_all():
 
 
 def test_heif_no_encoder():
-    with mock.patch.dict("pillow_heif.heif._pillow_heif.lib_info", {"libheif": "1.14.2", "HEIF": "", "AVIF": ""}):
+    def get_lib_info():
+        return {"libheif": "1.17.5", "HEIF": "", "AVIF": "", "encoders": {}, "decoders": {}}
+
+    with mock.patch("pillow_heif.heif._pillow_heif.get_lib_info", side_effect=get_lib_info):
         im_heif = pillow_heif.from_pillow(Image.new("L", (64, 64)))
         out_buffer = BytesIO()
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
Ref: #154

Changes proposed in this pull request:

 * `libheif_info` now returns additionally `encoders` and `decoders` keys

_This PR raises minimum `libheif` version to the `1.15.0`_
 
 This will allow to get the required `decoder_id` and pass it to `image.load()` or something like that in future to use selected decoder/encoder for the operation.
 
 ```python3
 
 {
        'libheif': '1.15.2',
        'HEIF': 'x265 HEVC encoder (3.4+31-6722fce1f)',
        'AVIF': 'AOMedia Project AV1 Encoder 3.7.0',
        'encoders': {
            'x265': 'x265 HEVC encoder (3.4+31-6722fce1f)',
            'aom': 'AOMedia Project AV1 Encoder v3.7.0',
            'mask': 'mask'
        },
        'decoders': {
            'libde265': 'libde265 HEVC decoder, version 1.0.12',
            'aom': 'AOMedia Project AV1 Decoder v3.7.0'
        }
}
```    
    
    
    

