### PR TITLE
CI: replace Alpine 3.17 with 3.19

### DIFF
--- a/.github/workflows/test-src-build-linux.yml
+++ b/.github/workflows/test-src-build-linux.yml
@@ -36,10 +36,10 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["amd64", "arm64"]
-        docker_file: ["Alpine_3_17", "Alpine_3_18", "Almalinux_9", "Debian_12"]
+        docker_file: ["Alpine_3_18", "Alpine_3_19", "Almalinux_9", "Debian_12"]
         include:
           - arch: "arm/v7"
-            docker_file: "Alpine_3_18"
+            docker_file: "Alpine_3_19"
           - arch: "arm/v7"
             docker_file: "Debian_12"
           - arch: "amd64"

--- a/docker/from_src/Alpine_3_19.Dockerfile
+++ b/docker/from_src/Alpine_3_19.Dockerfile
@@ -1,26 +1,21 @@
-FROM alpine:3.17 as base
+FROM alpine:3.19 as base
 
 RUN \
   apk add --no-cache \
     python3-dev \
     py3-pip \
     alpine-sdk \
-    cmake \
-    nasm \
-    aom-dev \
-    x265-dev \
+    libheif-dev \
     py3-numpy \
     py3-pillow
-
-RUN \
-  python3 -m pip install --upgrade pip
 
 FROM base as build_test
 
 COPY . /pillow_heif
 
 RUN \
-  python3 pillow_heif/libheif/linux_build_libs.py && \
+  python3 -m venv --system-site-packages myenv && \
+  source myenv/bin/activate && \
   if [ `getconf LONG_BIT` = 64 ]; then \
     python3 -m pip install -v "pillow_heif/.[tests]"; \
   else \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ Linux
     | **And of course you can build your own libheif library with your preferred encoders and decoders and use what you like.**
 
 There is many different ways how to build it from source. Main requirements are:
-    * ``libheif`` should be version >= ``1.16.1`` version.
+    * ``libheif`` should be version >= ``1.16.1`` version(recommended version is ``1.17.3`` or higher).
     * ``x265`` should support 10 - 12 bit encoding(if you want to save in that bitness)
     * ``aom`` should be >= ``3.3.0`` version
     * ``libde265`` should be >= ``1.0.8`` version
@@ -47,7 +47,7 @@ On `Ubuntu`:
 | :bash:`sudo apt update`
 | :bash:`sudo apt -y install libheif-dev`
 
-On `Alpine 18+`:
+On `Alpine 19`:
 
 | :bash:`sudo apk add --no-cache libheif-dev`
 


### PR DESCRIPTION
Since Alpine 3.19 has a libheif version (`1.17.3`) that suits us perfectly for the next six months or a year, we put it in the test matrix and remove Alpine 3.17.
