### PR TITLE
Preferred-encoder global option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 All notable changes to this project will be documented in this file.
 
-## [0.15.0 - 2024-01-xx]
+## [0.15.0 - 2024-0x-xx]
 
 ### Added
 
 - `libheif_info` function: added `encoders` and `decoders` keys to the result, for future libheif plugins support. #189
+- `options.PREFERRED_ENCODER` - to use `encoder` different from the default one. #192
 
 ### Changed
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -10,6 +10,7 @@ Options
 .. autodata:: pillow_heif.options.SAVE_HDR_TO_12_BIT
 .. autodata:: pillow_heif.options.ALLOW_INCORRECT_HEADERS
 .. autodata:: pillow_heif.options.SAVE_NCLX_PROFILE
+.. autodata:: pillow_heif.options.PREFERRED_ENCODER
 
 Example of use
 """"""""""""""

--- a/pillow_heif/constants.py
+++ b/pillow_heif/constants.py
@@ -49,19 +49,23 @@ class HeifCompressionFormat(IntEnum):
     UNDEFINED = 0
     """The compression format is not defined."""
     HEVC = 1
-    """The compression format is HEVC."""
+    """Equivalent to H.265."""
     AVC = 2
-    """The compression format is AVC."""
+    """Equivalent to H.264. Defined in ISO/IEC 14496-10."""
     JPEG = 3
-    """The compression format is JPEG."""
+    """JPEG compression. Defined in ISO/IEC 10918-1."""
     AV1 = 4
-    """The compression format is AV1."""
+    """AV1 compression, used for AVIF images."""
     VVC = 5
-    """The compression format is VVC."""
+    """Equivalent to H.266. Defined in ISO/IEC 23090-3."""
     EVC = 6
-    """The compression format is EVC."""
+    """Equivalent to H.266. Defined in ISO/IEC 23094-1."""
     JPEG2000 = 7
     """The compression format is JPEG200 ISO/IEC 15444-16:2021"""
+    UNCOMPRESSED = 8
+    """Defined in ISO/IEC 23001-17:2023 (Final Draft International Standard)."""
+    MASK = 9
+    """Mask image encoding. See ISO/IEC 23008-12:2022 Section 6.10.2"""
 
 
 class HeifColorPrimaries(IntEnum):

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -327,7 +327,11 @@ class CtxEncode:
 
     def __init__(self, compression_format: HeifCompressionFormat, **kwargs):
         quality = kwargs.get("quality", options.QUALITY)
-        self.ctx_write = _pillow_heif.CtxWrite(compression_format, -2 if quality is None else quality)
+        self.ctx_write = _pillow_heif.CtxWrite(
+            compression_format,
+            -2 if quality is None else quality,
+            options.PREFERRED_ENCODER.get("HEIF" if compression_format == HeifCompressionFormat.HEVC else "AVIF", ""),
+        )
         enc_params = kwargs.get("enc_params", {})
         chroma = kwargs.get("chroma", None)
         if chroma is None and "subsampling" in kwargs:

--- a/pillow_heif/options.py
+++ b/pillow_heif/options.py
@@ -57,3 +57,10 @@ Apple has already fixed this and there is no longer a need to not save the defau
 .. note:: `save_nclx_profile` specified during calling ``save`` has higher priority than this.
 
 When use pillow_heif as a plugin you can unset it with: `register_*_opener(save_nclx_profile=False)`"""
+
+
+PREFERRED_ENCODER = {
+    "AVIF": "",
+    "HEIF": "",
+}
+"""Use the specified encoder for format. You can get the available encoders IDs using ``libheif_info()`` function."""


### PR DESCRIPTION
Ref: #154


This allows to use specified  encoder by ID if **libehif** is built with it(or when plugin support in **libheif** is enabled and codec loaded as a plugin)

Ability to list encoders was added here: #189
