### PR TITLE
preferred-decoder option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - `libheif_info` function: added `encoders` and `decoders` keys to the result, for future libheif plugins support. #189
 - `options.PREFERRED_ENCODER` - to use `encoder` different from the default one. #192
+- `options.PREFERRED_DECODER` - to use `decoder` different from the default one. #193
 
 ### Changed
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -11,6 +11,7 @@ Options
 .. autodata:: pillow_heif.options.ALLOW_INCORRECT_HEADERS
 .. autodata:: pillow_heif.options.SAVE_NCLX_PROFILE
 .. autodata:: pillow_heif.options.PREFERRED_ENCODER
+.. autodata:: pillow_heif.options.PREFERRED_DECODER
 
 Example of use
 """"""""""""""

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -246,6 +246,10 @@ def __options_update(**kwargs):
             options.ALLOW_INCORRECT_HEADERS = v
         elif k == "save_nclx_profile":
             options.SAVE_NCLX_PROFILE = v
+        elif k == "preferred_encoder":
+            options.PREFERRED_ENCODER = v
+        elif k == "preferred_decoder":
+            options.PREFERRED_DECODER = v
         else:
             warn(f"Unknown option: {k}", stacklevel=1)
 

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -223,6 +223,12 @@ class HeifFile:
         else:
             fp_bytes = _get_bytes(fp)
             mimetype = get_file_mimetype(fp_bytes)
+            if mimetype.find("avif") != -1:
+                preferred_decoder = options.PREFERRED_DECODER.get("AVIF", "")
+            elif mimetype.find("heic") != -1 or mimetype.find("heif") != -1:
+                preferred_decoder = options.PREFERRED_DECODER.get("HEIF", "")
+            else:
+                preferred_decoder = ""
             images = _pillow_heif.load_file(
                 fp_bytes,
                 options.DECODE_THREADS,
@@ -231,6 +237,7 @@ class HeifFile:
                 kwargs.get("remove_stride", True),
                 kwargs.get("hdr_to_16bit", True),
                 kwargs.get("reload_size", options.ALLOW_INCORRECT_HEADERS),
+                preferred_decoder,
             )
         self.mimetype = mimetype
         self._images: List[HeifImage] = [HeifImage(i) for i in images if i is not None]

--- a/pillow_heif/options.py
+++ b/pillow_heif/options.py
@@ -63,4 +63,23 @@ PREFERRED_ENCODER = {
     "AVIF": "",
     "HEIF": "",
 }
-"""Use the specified encoder for format. You can get the available encoders IDs using ``libheif_info()`` function."""
+"""Use the specified encoder for format.
+
+You can get the available encoders IDs using ``libheif_info()`` function.
+
+When use pillow_heif as a plugin you can set this option with ``preferred_encoder`` key.
+
+.. note:: If the specified encoder is missing, the option will be ignored."""
+
+
+PREFERRED_DECODER = {
+    "AVIF": "",
+    "HEIF": "",
+}
+"""Use the specified decoder for format.
+
+You can get the available decoders IDs using ``libheif_info()`` function.
+
+When use pillow_heif as a plugin you can set this option with ``preferred_decoder`` key.
+
+.. note:: If the specified decoder is missing, the option will be ignored."""

--- a/tests/options_test.py
+++ b/tests/options_test.py
@@ -34,6 +34,8 @@ def test_options_change_from_plugin_registering(register_opener):
             decode_threads=3,
             depth_images=False,
             save_nclx_profile=False,
+            preferred_encoder={"HEIF": "id1", "AVIF": "id2"},
+            preferred_decoder={"HEIF": "id3", "AVIF": "id4"},
         )
         assert not options.THUMBNAILS
         assert options.QUALITY == 69
@@ -41,6 +43,8 @@ def test_options_change_from_plugin_registering(register_opener):
         assert options.DECODE_THREADS == 3
         assert options.DEPTH_IMAGES is False
         assert options.SAVE_NCLX_PROFILE is False
+        assert options.PREFERRED_ENCODER == {"HEIF": "id1", "AVIF": "id2"}
+        assert options.PREFERRED_DECODER == {"HEIF": "id3", "AVIF": "id4"}
     finally:
         options.THUMBNAILS = True
         options.QUALITY = None
@@ -48,6 +52,8 @@ def test_options_change_from_plugin_registering(register_opener):
         options.DECODE_THREADS = 4
         options.DEPTH_IMAGES = True
         options.SAVE_NCLX_PROFILE = True
+        options.PREFERRED_ENCODER = {"HEIF": "", "AVIF": ""}
+        options.PREFERRED_DECODER = {"HEIF": "", "AVIF": ""}
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="No HEVC encoder.")

--- a/tests/read_test.py
+++ b/tests/read_test.py
@@ -470,3 +470,20 @@ def test_depth_image():
     assert depth_image.info["metadata"]["disparity_reference_view"] == 0
     assert depth_image.info["metadata"]["nonlinear_representation_model_size"] == 0
     assert im_pil.info == depth_image.info
+
+
+def test_invalid_decoder():
+    try:
+        pillow_heif.options.PREFERRED_DECODER["HEIF"] = "invalid_id"
+        Image.open("images/heif/RGB_8__128x128.heif").load()
+    finally:
+        pillow_heif.options.PREFERRED_DECODER["HEIF"] = ""
+
+
+@pytest.mark.skipif("dav1d" not in pillow_heif.libheif_info()["decoders"], reason="Requires DAV1D AVIF decoder.")
+def test_dav1d_decoder():
+    try:
+        pillow_heif.options.PREFERRED_DECODER["AVIF"] = "dav1d"
+        Image.open("images/heif/RGB_8__128x128.avif").load()
+    finally:
+        pillow_heif.options.PREFERRED_DECODER["AVIF"] = ""

--- a/tests/write_test.py
+++ b/tests/write_test.py
@@ -589,10 +589,8 @@ def test_invalid_encoder():
     try:
         pillow_heif.options.PREFERRED_ENCODER["AVIF"] = "invalid_id"
         pillow_heif.options.PREFERRED_ENCODER["HEIF"] = "invalid_id"
-        with pytest.raises(RuntimeError):
-            im_rgb.save(buf, format="AVIF")
-        with pytest.raises(RuntimeError):
-            im_rgb.save(buf, format="HEIF")
+        im_rgb.save(buf, format="AVIF")
+        im_rgb.save(buf, format="HEIF")
     finally:
         pillow_heif.options.PREFERRED_ENCODER["AVIF"] = ""
         pillow_heif.options.PREFERRED_ENCODER["HEIF"] = ""


### PR DESCRIPTION
Ref: #154

Changes proposed in this pull request:

 * Implemented PREFERRED_DECODER in the same way, as PREFERRED_ENCODER in #192
 * PREFERRED_ENCODER now does not raise `RuntimeError` when specified encoder is not found.
 * Added support of `preferred_encoder` and `preferred_decoder` keys to "register_avif_opener"/"register_heif_opener" function to easier set it in WSGI applications.

