### PR TITLE
fixed Windows, FreeBSD CI

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -195,6 +195,8 @@ jobs:
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libdav1d-7.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/rav1e.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libSvtAv1Enc.dll $site_packages/
+          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libkvazaar-7.dll $site_packages/
+          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libcryptopp.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libjpeg-8.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libopenjp2-7.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/zlib1.dll $site_packages/

--- a/ci/cirrus_general_ci.yml
+++ b/ci/cirrus_general_ci.yml
@@ -62,18 +62,19 @@ test_src_build_full_freebsd_task:
     'setup.*',
     'pyproject.toml')"
 
-  name: From source(FreeBSD) / FreeBSD:13-amd64
+  name: From source(FreeBSD) / FreeBSD:14-amd64
   freebsd_instance:
-    image_family: freebsd-13-2
+    image_family: freebsd-14-0
 
   env:
     PH_FULL_ACTION: 1
     EXP_PH_LIBHEIF_VERSION: ""
 
   install_libheif_script:
-    - pkg install -y libheif gcc
+    - pkg install -y gcc cmake aom x265
     - pkg install -y py39-pip
     - pkg install -y py39-pillow py39-numpy
+    - python3 libheif/linux_build_libs.py
   install_pillow_heif_script:
     - python3 -m pip -v install ".[tests-min]"
   libheif_info_script:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -72,9 +72,12 @@ FreeBSD
 
 Since Python itself does not support binary wheels for BSD systems, you should install libheif and then simply install Pillow-Heif from source.
 
-Install `libeheif` and `gcc`::
+Install `gcc`, `cmake`, `aom` and `x265`::
 
-    pkg install -y libheif gcc
+    - pkg install -y gcc cmake aom x265
+    - pkg install -y py39-pip
+    - pkg install -y py39-pillow py39-numpy
+    - python3 libheif/linux_build_libs.py
 
 Install Python and Pillow::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ extend-ignore = ["D107", "D105", "D203", "D213", "D401", "E203", "I001", "RUF100
 "setup.py" = ["S"]
 
 [tool.ruff.extend-per-file-ignores]
-"benchmarks/**/*.py" = ["D", "S603"]
+"benchmarks/**/*.py" = ["D", "S404", "S603"]
 "docs/**/*.py" = ["D"]
 "examples/**/*.py" = ["D", "PERF"]
 "libheif/**/*.py" = ["D", "PERF", "S"]


### PR DESCRIPTION
MSYS2 added `kvazaar` HEVC encoder, so added copy operation of kvazaar binaries to `site_packages`.