### PR TITLE
encode: `subsampling` parameter higher priority over `chroma`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## [0.16.0 - 2024-02-2x]
+
+### Changed
+
+- `subsampling` parameter for encoding has higher  priority then `chroma`.
+
 ## [0.15.0 - 2024-02-03]
 
 ### Added

--- a/pillow_heif/_version.py
+++ b/pillow_heif/_version.py
@@ -1,3 +1,3 @@
 """Version of pillow_heif/pi_heif."""
 
-__version__ = "0.15.0"
+__version__ = "0.16.0.dev0"

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -333,9 +333,11 @@ class CtxEncode:
             options.PREFERRED_ENCODER.get("HEIF" if compression_format == HeifCompressionFormat.HEVC else "AVIF", ""),
         )
         enc_params = kwargs.get("enc_params", {})
-        chroma = kwargs.get("chroma", None)
-        if chroma is None and "subsampling" in kwargs:
+        chroma = None
+        if "subsampling" in kwargs:
             chroma = SUBSAMPLING_CHROMA_MAP.get(kwargs["subsampling"], None)
+        if chroma is None:
+            chroma = kwargs.get("chroma", None)
         if chroma:
             enc_params["chroma"] = chroma
         for key, value in enc_params.items():


### PR DESCRIPTION
This will be need to introduce reading of image's `chroma` value in next PR.
