### PR TITLE
bump the minimum  required `libheif` version to `1.17.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- `subsampling` parameter for encoding has higher  priority then `chroma`.
+- `subsampling` parameter for encoding has higher  priority then `chroma`. #213
+- the minimum required `libehif` version is `1.17.0`. #214
 
 ## [0.15.0 - 2024-02-03]
 

--- a/docker/from_src/Almalinux_9.Dockerfile
+++ b/docker/from_src/Almalinux_9.Dockerfile
@@ -3,8 +3,8 @@ FROM almalinux:9 as base
 RUN \
   dnf install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm -y && \
   dnf makecache && \
-  dnf install -y python3 python3-devel python3-pip libheif-freeworld && \
-  dnf install -y libheif-devel && \
+  dnf install -y python3 python3-devel python3-pip cmake && \
+  dnf install -y x265-devel libaom-devel && \
   dnf groupinstall -y 'Development Tools'
 
 RUN \
@@ -15,6 +15,7 @@ FROM base as build_test
 COPY . /pillow_heif
 
 RUN \
+  python3 pillow_heif/libheif/linux_build_libs.py && \
   if [ `getconf LONG_BIT` = 64 ]; then \
     python3 -m pip install -v "pillow_heif/.[tests]"; \
   else \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ Linux
     | **And of course you can build your own libheif library with your preferred encoders and decoders and use what you like.**
 
 There is many different ways how to build it from source. Main requirements are:
-    * ``libheif`` should be version >= ``1.16.1`` version(recommended version is ``1.17.3`` or higher).
+    * ``libheif`` should be version >= ``1.17.0`` version(recommended version is ``1.17.3`` or higher).
     * ``x265`` should support 10 - 12 bit encoding(if you want to save in that bitness)
     * ``aom`` should be >= ``3.3.0`` version
     * ``libde265`` should be >= ``1.0.8`` version

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -16,10 +16,6 @@ def test_libheif_info():
     for key in ("HEIF", "AVIF", "encoders", "decoders"):
         assert key in info
     assert pillow_heif.libheif_version() in (
-        "1.15.1",
-        "1.15.2",
-        "1.16.1",
-        "1.16.2",
         "1.17.1",
         "1.17.3",
         "1.17.4",


### PR DESCRIPTION
We really need the `heif_image_handle_get_preferred_decoding_colorspace` function, which is only available from version "1.17.0"

_Almost all OS'es already have this version._

Ref: https://github.com/strukturag/libheif/issues/926