### PR TITLE
Fixed  CI error with Pillow 10.3.dev0

### DIFF
--- a/tests/write_test.py
+++ b/tests/write_test.py
@@ -316,7 +316,7 @@ def test_I_color_modes_to_10_12_bit(enc_bits, save_format):  # noqa
     try:
         pillow_heif.options.SAVE_HDR_TO_12_BIT = bool(enc_bits == 12)
         src_pillow = Image.open(Path("images/non_heif/L_16__29x100.png"))
-        assert src_pillow.mode == "I"
+        assert src_pillow.mode in ("I", "I;16")  # Pillow 10.3+ will open in `I;16`
         for mode in ("I", "I;16", "I;16L"):
             i_mode_img = src_pillow.convert(mode=mode)
             out_heic = BytesIO()


### PR DESCRIPTION
Starting from Pillow `10.3` version grayscale PNG opened in `I;16` mode instead of `I`.

Ref: https://github.com/python-pillow/Pillow/pull/7849