### PR TITLE
corrected processing of images in P mode with transparency=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## [0.x.x - 2024-0x-xx]
+
+### Fixed
+
+- Processing of the images in `P` mode with `transparency` = 0. #238
+
 ## [0.16.0 - 2024-04-02]
 
 This release contains breaking change for monochrome images.

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -282,7 +282,7 @@ def _xmp_from_pillow(img: Image.Image) -> Optional[bytes]:
 def _pil_to_supported_mode(img: Image.Image) -> Image.Image:
     # We support "YCbCr" for encoding in Pillow plugin mode and do not call this function.
     if img.mode == "P":
-        mode = "RGBA" if img.info.get("transparency") else "RGB"
+        mode = "RGBA" if img.info.get("transparency", None) is not None else "RGB"
         img = img.convert(mode=mode)
     elif img.mode == "I":
         img = img.convert(mode="I;16L")


### PR DESCRIPTION
It only corrects the situation when the image is already transparency.

Passing the `transparency` flag itself to `save` function for HEIC/AVIF continues to be ignored, as it was ignored.

Reference: #235