### PR TITLE
bumped minimum required Pillow version to `10.1.0`

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -250,7 +250,7 @@ jobs:
 
       - name: Install from source
         run: |
-          python -m pip install pillow==9.5.0
+          python -m pip install pillow==10.1.0
           python -m pip -v install ".[dev]"
 
       - name: LibHeif info
@@ -294,7 +294,7 @@ jobs:
 
       - name: Install from source
         run: |
-          sudo -H python3 -m pip install pillow==10.0.1 pytest defusedxml packaging numpy coverage
+          sudo -H python3 -m pip install pillow==10.3.0 pytest defusedxml packaging numpy coverage
           sudo -H PH_LIGHT_ACTION=1 python3 libheif/linux_build_libs.py
           sudo -H python3 -m pip -v install --no-build-isolation .
 

--- a/.github/workflows/test-src-build-linux.yml
+++ b/.github/workflows/test-src-build-linux.yml
@@ -36,10 +36,10 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["amd64", "arm64"]
-        docker_file: ["Alpine_3_18", "Alpine_3_19", "Almalinux_9", "Debian_12"]
+        docker_file: ["Alpine_3_19", "Alpine_3_20", "Almalinux_9", "Debian_12"]
         include:
           - arch: "arm/v7"
-            docker_file: "Alpine_3_19"
+            docker_file: "Alpine_3_20"
           - arch: "arm/v7"
             docker_file: "Debian_12"
           - arch: "amd64"

--- a/.github/workflows/test-wheels-pi_heif.yml
+++ b/.github/workflows/test-wheels-pi_heif.yml
@@ -24,12 +24,12 @@ jobs:
           { "os": "debian", "ver": "12", "arch": "amd64" },
           { "os": "debian", "ver": "12", "arch": "arm64" },
           { "os": "debian", "ver": "12", "arch": "arm/v7" },
-          { "os": "alpine", "ver": "3.18", "arch": "amd64" },
-          { "os": "alpine", "ver": "3.18", "arch": "arm64" },
-          { "os": "alpine", "ver": "3.18", "arch": "arm/v7" },
           { "os": "alpine", "ver": "3.19", "arch": "amd64" },
           { "os": "alpine", "ver": "3.19", "arch": "arm64" },
           { "os": "alpine", "ver": "3.19", "arch": "arm/v7" },
+          { "os": "alpine", "ver": "3.20", "arch": "amd64" },
+          { "os": "alpine", "ver": "3.20", "arch": "arm64" },
+          { "os": "alpine", "ver": "3.20", "arch": "arm/v7" },
         ]
 
     steps:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -22,10 +22,10 @@ jobs:
           { "os": "debian", "ver": "11", "arch": "arm64" },
           { "os": "debian", "ver": "12", "arch": "amd64" },
           { "os": "debian", "ver": "12", "arch": "arm64" },
-          { "os": "alpine", "ver": "3.18", "arch": "amd64" },
-          { "os": "alpine", "ver": "3.18", "arch": "arm64" },
           { "os": "alpine", "ver": "3.19", "arch": "amd64" },
           { "os": "alpine", "ver": "3.19", "arch": "arm64" },
+          { "os": "alpine", "ver": "3.20", "arch": "amd64" },
+          { "os": "alpine", "ver": "3.20", "arch": "arm64" },
         ]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 
-## [0.x.x - 2024-0x-xx]
+## [0.17.0 - 2024-07-02]
+
+### Changed
+
+- Minimum supported Pillow version raised to `10.1.0`. #251
 
 ### Fixed
 

--- a/docker/from_src/Alpine_3_19.Dockerfile
+++ b/docker/from_src/Alpine_3_19.Dockerfile
@@ -5,7 +5,11 @@ RUN \
     python3-dev \
     py3-pip \
     alpine-sdk \
-    libheif-dev \
+    cmake \
+    nasm \
+    aom-dev \
+    x265-dev \
+    libde265-dev \
     py3-numpy \
     py3-pillow
 
@@ -16,6 +20,7 @@ COPY . /pillow_heif
 RUN \
   python3 -m venv --system-site-packages myenv && \
   source myenv/bin/activate && \
+  python3 pillow_heif/libheif/linux_build_libs.py && \
   if [ `getconf LONG_BIT` = 64 ]; then \
     python3 -m pip install -v "pillow_heif/.[tests]"; \
   else \

--- a/docker/from_src/Alpine_3_20.Dockerfile
+++ b/docker/from_src/Alpine_3_20.Dockerfile
@@ -1,27 +1,21 @@
-FROM alpine:3.18 as base
+FROM alpine:3.20 as base
 
 RUN \
   apk add --no-cache \
     python3-dev \
     py3-pip \
     alpine-sdk \
-    cmake \
-    nasm \
-    aom-dev \
-    x265-dev \
-    libde265-dev \
+    libheif-dev \
     py3-numpy \
     py3-pillow
-
-RUN \
-  python3 -m pip install --upgrade pip
 
 FROM base as build_test
 
 COPY . /pillow_heif
 
 RUN \
-  python3 pillow_heif/libheif/linux_build_libs.py && \
+  python3 -m venv --system-site-packages myenv && \
+  source myenv/bin/activate && \
   if [ `getconf LONG_BIT` = 64 ]; then \
     python3 -m pip install -v "pillow_heif/.[tests]"; \
   else \

--- a/docker/musllinux_armv7l_wheels.Dockerfile
+++ b/docker/musllinux_armv7l_wheels.Dockerfile
@@ -1,6 +1,6 @@
 ARG PY_VERSION
 
-FROM python:$PY_VERSION-alpine3.18
+FROM python:$PY_VERSION-alpine3.19
 
 COPY . /
 

--- a/pi-heif/setup.cfg
+++ b/pi-heif/setup.cfg
@@ -37,7 +37,7 @@ python_requires = >=3.8
 zip_safe = False
 packages = find:
 install_requires =
-    pillow>=9.5.0
+    pillow>=10.1.0
 
 [options.extras_require]
 tests-min =

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -5,7 +5,6 @@ from typing import Union
 from warnings import warn
 
 from PIL import Image, ImageFile, ImageSequence
-from PIL import __version__ as pil_version
 
 from . import options
 from .constants import HeifCompressionFormat
@@ -119,11 +118,7 @@ class _LibHeifImageFile(ImageFile.ImageFile):
     def _init_from_heif_file(self, img_index: int) -> None:
         if self._heif_file:
             self._size = self._heif_file[img_index].size
-            if pil_version[:4] not in ("9.5.", "10.0"):
-                # starting from Pillow 10.1, `mode` is a readonly property.
-                self._mode = self._heif_file[img_index].mode
-            else:
-                self.mode = self._heif_file[img_index].mode
+            self._mode = self._heif_file[img_index].mode
             self.info = self._heif_file[img_index].info
             self.info["original_orientation"] = set_orientation(self.info)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ python_requires = >=3.8
 zip_safe = False
 packages = find:
 install_requires =
-    pillow>=9.5.0
+    pillow>=10.1.0
 
 [options.extras_require]
 docs =

--- a/tests/options_test.py
+++ b/tests/options_test.py
@@ -11,7 +11,6 @@ from PIL import Image, UnidentifiedImageError
 
 from pillow_heif import (
     from_pillow,
-    libheif_version,
     open_heif,
     options,
     read_heif,
@@ -95,7 +94,6 @@ def test_quality_option(save_format):
 @pytest.mark.skipif(os.cpu_count() < 2, reason="Requires at least a processor with two cores.")
 @pytest.mark.skipif(os.getenv("TEST_DECODE_THREADS", "1") == "0", reason="TEST_DECODE_THREADS set to `0`")
 @pytest.mark.skipif(sys.maxsize <= 2147483647, reason="Run test only on 64 bit CPU.")
-@pytest.mark.skipif(libheif_version() == "1.12.0", reason="`DECODE_THREADS` parameter is not supported.")
 @pytest.mark.skipif(machine() in ("arm64", "aarch64") and sys.platform.lower() == "linux", reason="skip emulator")
 def test_decode_threads():
     test_image = "images/heif_other/arrow.heic"  # not all images can be decoded using more than one thread


### PR DESCRIPTION
For now we are simply increasing the minimum version of Pillov.

Tests for the dev version of Pillow 10.4.0 will fail - this is normal and will be fixed in a separate pull request.