### PR TITLE
fixed CI due to changes in `x265` MSYS2 repo

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -231,7 +231,7 @@ jobs:
           Get-ChildItem -Path $Env:MSYS2_PREFIX/bin -Force | Format-List
           cp ${{ env.MSYS2_PREFIX }}/bin/libheif.dll $site_packages/
           cp ${{ env.MSYS2_PREFIX }}/bin/libde265-0.dll $site_packages/
-          cp ${{ env.MSYS2_PREFIX }}/bin/libx265.dll $site_packages/
+          cp ${{ env.MSYS2_PREFIX }}/bin/libx265*.dll $site_packages/
           cp ${{ env.MSYS2_PREFIX }}/bin/libaom.dll $site_packages/
           cp ${{ env.MSYS2_PREFIX }}/bin/libwinpthread-1.dll $site_packages/
           cp ${{ env.MSYS2_PREFIX }}/bin/libgcc_s_seh-1.dll $site_packages/

--- a/.github/workflows/test-src-build-windows.yml
+++ b/.github/workflows/test-src-build-windows.yml
@@ -63,9 +63,10 @@ jobs:
       - name: Copy DLLs from MSYS2
         run: |
           $site_packages=(python -c 'import sysconfig; print(sysconfig.get_paths()["platlib"])')
+          Get-ChildItem -Path $Env:MSYS2_PREFIX/bin -Force | Format-List
           cp ${{ env.MSYS2_PREFIX }}/bin/libheif.dll $site_packages/
           cp ${{ env.MSYS2_PREFIX }}/bin/libde265-0.dll $site_packages/
-          cp ${{ env.MSYS2_PREFIX }}/bin/libx265.dll $site_packages/
+          cp ${{ env.MSYS2_PREFIX }}/bin/libx265*.dll $site_packages/
           cp ${{ env.MSYS2_PREFIX }}/bin/libaom.dll $site_packages/
           cp ${{ env.MSYS2_PREFIX }}/bin/libwinpthread-1.dll $site_packages/
           cp ${{ env.MSYS2_PREFIX }}/bin/libgcc_s_seh-1.dll $site_packages/

--- a/.github/workflows/wheels-pillow_heif.yml
+++ b/.github/workflows/wheels-pillow_heif.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Remove DLL trailing data
         run: |
+          Get-ChildItem -Path $Env:MSYS2_PREFIX/bin -Force | Format-List
           ${{ env.MSYS2_PREFIX }}/bin/strip -s -v ${{ env.MSYS2_PREFIX }}/bin/libheif.dll
           ${{ env.MSYS2_PREFIX }}/bin/strip -s -v ${{ env.MSYS2_PREFIX }}/bin/libde265-0.dll
           ${{ env.MSYS2_PREFIX }}/bin/strip -s -v ${{ env.MSYS2_PREFIX }}/bin/libx265.dll

--- a/pillow_heif/_version.py
+++ b/pillow_heif/_version.py
@@ -1,3 +1,3 @@
 """Version of pillow_heif/pi_heif."""
 
-__version__ = "0.16.0"
+__version__ = "0.17.0.dev0"


### PR DESCRIPTION
Now `libx265.dll` has a dynamic name based on version(not sure that I will port this change to the Wheels release action).

Reference: https://github.com/msys2/MINGW-packages/commit/29e2cbd96b51fb2adfe451d5cdff68cfdcb0b664