### PR TITLE
Fix build with Python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,12 @@ class RequiredDependencyException(Exception):
 def get_version():
     """Returns version of the project."""
     version_file = "pillow_heif/_version.py"
-    exec(compile(Path(version_file).read_text(encoding="utf-8"), version_file, "exec"))  # pylint: disable=exec-used
-    return locals()["__version__"]
+    result = {}
+    exec(  # pylint: disable=exec-used
+        compile(Path(version_file).read_text(encoding="utf-8"), version_file, "exec"),
+        result,
+    )
+    return result["__version__"]
 
 
 def _cmd_exists(cmd: str) -> bool:


### PR DESCRIPTION
Python 3.13 has changed how `locals()` works [1], so this code needs to be a bit more explicit.

[1] https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals