### PR TITLE
Parse _version contents instead of using exec()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,8 @@ class RequiredDependencyException(Exception):
 
 def get_version():
     """Returns version of the project."""
-    version_file = "pillow_heif/_version.py"
-    exec(compile(Path(version_file).read_text(encoding="utf-8"), version_file, "exec"))  # pylint: disable=exec-used
-    return locals()["__version__"]
+    match = re.search(r'__version__\s*=\s*"(.*?)"', Path("pillow_heif/_version.py").read_text(encoding="utf-8"))
+    return match.group(1)
 
 
 def _cmd_exists(cmd: str) -> bool:


### PR DESCRIPTION
Starting to use `re.search` to get version from file.

References:

https://github.com/bigcat88/pillow_heif/pull/256 
https://github.com/python-pillow/Pillow/pull/8050