### PR TITLE
bumped `cibuildwheel` to `2.19.1` version

### DIFF
--- a/.github/workflows/build-cache-deps.yml
+++ b/.github/workflows/build-cache-deps.yml
@@ -39,7 +39,7 @@ jobs:
           platforms: arm64
 
       - name: Install cibuildwheel & twine
-        run: python3 -m pip install twine cibuildwheel==2.17.0
+        run: python3 -m pip install twine cibuildwheel==2.19.1
 
       - uses: actions/cache@v4
         with:
@@ -98,7 +98,7 @@ jobs:
           platforms: arm64
 
       - name: Install cibuildwheel & twine
-        run: python3 -m pip install twine cibuildwheel==2.17.0
+        run: python3 -m pip install twine cibuildwheel==2.19.1
 
       - name: 32-bit musllinux preparations
         if: matrix.cibw_buildlinux == 'musllinux' && matrix.cibw_arch == 'i686'

--- a/.github/workflows/wheels-pi_heif.yml
+++ b/.github/workflows/wheels-pi_heif.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.17.0
+          python3 -m pip install cibuildwheel==2.19.1
           python3 -m cibuildwheel
         env:
           CIBW_ARCHS: "AMD64"
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.17.0
+          python3 -m pip install cibuildwheel==2.19.1
           python3 -m cibuildwheel
         env:
           CIBW_ARCHS: "x86_64"
@@ -170,7 +170,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.17.0
+          python3 -m pip install cibuildwheel==2.19.1
           python3 -m cibuildwheel
         env:
           CIBW_BUILD: ${{ format('cp3*-{0}_{1}', matrix.cibw_buildlinux, matrix.cibw_arch) }}
@@ -230,7 +230,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.17.0
+          python3 -m pip install cibuildwheel==2.19.1
           python3 -m cibuildwheel
         env:
           CIBW_BUILD: ${{ format('pp3*-{0}_{1}', matrix.cibw_buildlinux, matrix.cibw_arch) }}

--- a/.github/workflows/wheels-pillow_heif.yml
+++ b/.github/workflows/wheels-pillow_heif.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.17.0
+          python3 -m pip install cibuildwheel==2.19.1
           python3 -m cibuildwheel
         env:
           CIBW_ARCHS: "AMD64"
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.17.0
+          python3 -m pip install cibuildwheel==2.19.1
           python3 -m cibuildwheel
         env:
           CIBW_ARCHS: "x86_64"
@@ -165,7 +165,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.17.0
+          python3 -m pip install cibuildwheel==2.19.1
           python3 -m cibuildwheel
         env:
           CIBW_BUILD: ${{ format('cp3*-{0}_{1}', matrix.cibw_buildlinux, matrix.cibw_arch) }}
@@ -229,7 +229,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel==2.17.0
+          python3 -m pip install cibuildwheel==2.19.1
           python3 -m cibuildwheel
         env:
           CIBW_BUILD: ${{ format('pp3*-{0}_{1}', matrix.cibw_buildlinux, matrix.cibw_arch) }}

--- a/ci/cirrus_wheels.yml
+++ b/ci/cirrus_wheels.yml
@@ -16,7 +16,7 @@ wheel_macos_arm_task:
     - brew install python@3.10
     - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
   install_cibuildwheel_script:
-    - python3 -m pip install cibuildwheel==2.17.0
+    - python3 -m pip install cibuildwheel==2.19.1
   run_cibuildwheel_script:
     - python3 -m cibuildwheel
   wheels_artifacts:
@@ -40,7 +40,7 @@ wheel_pi_heif_macos_arm_task:
     - brew install python@3.10
     - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
   install_cibuildwheel_script:
-    - python3 -m pip install cibuildwheel==2.17.0
+    - python3 -m pip install cibuildwheel==2.19.1
   transform_to_pi_heif_script:
     - cp -r -v ./pi-heif/* .
     - python3 .github/transform_to-pi_heif.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,6 @@ before-build = [
   "pip install delvewheel",
 ]
 
-[tool.cibuildwheel.linux]
-musllinux-i686-image = "musllinux_1_2"
-musllinux-x86_64-image = "musllinux_1_2"
-musllinux-aarch64-image = "musllinux_1_2"
-
 [tool.black]
 line-length = 120
 target-versions = [


### PR DESCRIPTION
This version of **cibuildwheel** defaults to musllinux_1_2, so removed that overriding in `pyproject.toml`