### PR TITLE
adjusted tests for `1.18.0` libheif

### DIFF
--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -15,13 +15,10 @@ def test_libheif_info():
     info = pillow_heif.libheif_info()
     for key in ("HEIF", "AVIF", "encoders", "decoders"):
         assert key in info
-    assert pillow_heif.libheif_version() in (
-        "1.17.1",
-        "1.17.3",
-        "1.17.4",
-        "1.17.5",
-        "1.17.6",
-    )
+
+    version = pillow_heif.libheif_version()
+    valid_prefixes = ["1.17.", "1.18."]
+    assert any(version.startswith(prefix) for prefix in valid_prefixes)
 
 
 @pytest.mark.skipif(helpers.aom(), reason="Only when AVIF support missing.")

--- a/tests/read_test.py
+++ b/tests/read_test.py
@@ -99,8 +99,8 @@ def test_heif_corrupted_open(img_path):
 @pytest.mark.parametrize("img_path", dataset.CORRUPTED_DATASET)
 def test_pillow_corrupted_open(img_path):
     for input_type in [BytesIO(img_path.read_bytes()), img_path, builtins.open(img_path, "rb")]:
-        with pytest.raises(UnidentifiedImageError):
-            Image.open(input_type)
+        with pytest.raises((UnidentifiedImageError, ValueError)):
+            Image.open(input_type).load()
 
 
 def test_heif_image_order():


### PR DESCRIPTION
1. made more universal `libheif` version check, to not adjust it after changing `bugfix` version(last digit in libheif version)
2. on one of the corrupted files the new version of libheif throws error only on decoding and not on opening 