### PR TITLE
updated libheif to `1.18.1` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## [0.18.0 - 2024-0x-xx]
+
+### Changed
+
+- libheif updated from `1.17.6` to `1.18.1` version.
+
 ## [0.17.0 - 2024-07-02]
 
 ### Added

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -14,7 +14,7 @@ PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/get/0b75c44c10e605fe9e9ebed58f04a46271131827.tar.gz"
 LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.6.1.tar.gz"
 LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.15/libde265-1.0.15.tar.gz"
-LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.17.6/libheif-1.17.6.tar.gz"
+LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.18.1/libheif-1.18.1.tar.gz"
 
 
 def download_file(url: str, out_path: str) -> bool:
@@ -187,6 +187,9 @@ def build_lib_linux(url: str, name: str):
             cmake_args += ["-DCMAKE_BUILD_TYPE=Release"]
             if name == "libheif":
                 cmake_args += (
+                    "-DWITH_OPENJPH_DECODER=OFF "
+                    "-DWITH_OPENJPH_ENCODER=OFF "
+                    "-DWITH_HEADER_COMPRESSION=OFF "
                     "-DWITH_LIBDE265=ON "
                     "-DWITH_LIBDE265_PLUGIN=OFF "
                     "-DWITH_X265=ON "

--- a/libheif/macos/libheif.rb
+++ b/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.17.6/libheif-1.17.6.tar.gz"
-  sha256 "8390baf4913eda0a183e132cec62b875fb2ef507ced5ddddc98dfd2f17780aee"
+  url "https://github.com/strukturag/libheif/releases/download/v1.18.1/libheif-1.18.1.tar.gz"
+  sha256 "8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10
@@ -20,6 +20,9 @@ class Libheif < Formula
 
   def install
     args = %W[
+      -DWITH_OPENJPH_DECODER=OFF
+      -DWITH_OPENJPH_ENCODER=OFF
+      -DWITH_HEADER_COMPRESSION=OFF
       -DWITH_LIBDE265=ON
       -DWITH_LIBDE265_PLUGIN=OFF
       -DWITH_X265=ON

--- a/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.17.6
+pkgver=1.18.1
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-x265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8390baf4913eda0a183e132cec62b875fb2ef507ced5ddddc98dfd2f17780aee')
+sha256sums=('8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
@@ -35,6 +35,9 @@ build() {
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
+      -DWITH_OPENJPH_DECODER=OFF \
+      -DDWITH_OPENJPH_ENCODER=OFF \
+      -DWITH_HEADER_COMPRESSION=OFF \
       -DWITH_LIBDE265=ON \
       -DWITH_LIBDE265_PLUGIN=OFF \
       -DWITH_X265=ON \

--- a/pi-heif/libheif/macos/libheif.rb
+++ b/pi-heif/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.17.6/libheif-1.17.6.tar.gz"
-  sha256 "8390baf4913eda0a183e132cec62b875fb2ef507ced5ddddc98dfd2f17780aee"
+  url "https://github.com/strukturag/libheif/releases/download/v1.18.1/libheif-1.18.1.tar.gz"
+  sha256 "8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10
@@ -15,6 +15,9 @@ class Libheif < Formula
 
   def install
     args = %W[
+      -DWITH_OPENJPH_DECODER=OFF
+      -DWITH_OPENJPH_ENCODER=OFF
+      -DWITH_HEADER_COMPRESSION=OFF
       -DWITH_LIBDE265=ON
       -DWITH_LIBDE265_PLUGIN=OFF
       -DWITH_X265=OFF

--- a/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.17.6
+pkgver=1.18.1
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8390baf4913eda0a183e132cec62b875fb2ef507ced5ddddc98dfd2f17780aee')
+sha256sums=('8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}
@@ -32,6 +32,9 @@ build() {
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${extra_config[@]}" \
       -DBUILD_SHARED_LIBS=ON \
+      -DWITH_OPENJPH_DECODER=OFF \
+      -DDWITH_OPENJPH_ENCODER=OFF \
+      -DWITH_HEADER_COMPRESSION=OFF \
       -DWITH_LIBDE265=ON \
       -DWITH_LIBDE265_PLUGIN=OFF \
       -DWITH_X265=OFF \

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -105,7 +105,7 @@ def test_full_build():
     assert info["HEIF"]
     assert info["encoders"]
     assert info["decoders"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.6")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.18.1")
     if expected_version:
         assert info["libheif"] == expected_version
 
@@ -116,7 +116,7 @@ def test_light_build():
     assert not info["AVIF"]
     assert not info["HEIF"]
     assert info["decoders"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.17.6")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.18.1")
     if expected_version:
         assert info["libheif"] == expected_version
 


### PR DESCRIPTION
This version of libheif can open files from iOS18.

ref: #249