### PR TITLE
CI: copy libopenjph.dll for Windows by wildcard

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -258,7 +258,7 @@ jobs:
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libdeflate.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libjbig-0.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libtiffxx-6.dll $site_packages/
-          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libopenjph-0.14.dll $site_packages/
+          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libopenjph-0.*.dll $site_packages/
 
       - name: Install from source
         run: |


### PR DESCRIPTION
To not fix CI every week, lets just use `*` to always copy the library with any minor version. (maybe for major version thees needs too?)

ref: https://github.com/msys2/MINGW-packages/commit/de039d78c8f67744e73a9f93d30147ec35d76170