### PR TITLE
chore: update `libheif` to the `1.18.2` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## [0.19.0 - 2024-10-16]
+
+### Changed
+
+- libheif updated from `1.18.1` to `1.18.2` version.
+
 ## [0.18.0 - 2024-07-27]
 
 ### Added

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -14,7 +14,7 @@ PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/get/0b75c44c10e605fe9e9ebed58f04a46271131827.tar.gz"
 LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.6.1.tar.gz"
 LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.15/libde265-1.0.15.tar.gz"
-LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.18.1/libheif-1.18.1.tar.gz"
+LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.18.2/libheif-1.18.2.tar.gz"
 
 
 def download_file(url: str, out_path: str) -> bool:

--- a/libheif/macos/libheif.rb
+++ b/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.18.1/libheif-1.18.1.tar.gz"
-  sha256 "8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76"
+  url "https://github.com/strukturag/libheif/releases/download/v1.18.2/libheif-1.18.2.tar.gz"
+  sha256 "c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10

--- a/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.18.1
+pkgver=1.18.2
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-x265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76')
+sha256sums=('c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/pi-heif/libheif/macos/libheif.rb
+++ b/pi-heif/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.18.1/libheif-1.18.1.tar.gz"
-  sha256 "8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76"
+  url "https://github.com/strukturag/libheif/releases/download/v1.18.2/libheif-1.18.2.tar.gz"
+  sha256 "c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10

--- a/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.18.1
+pkgver=1.18.2
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76')
+sha256sums=('c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/pillow_heif/_version.py
+++ b/pillow_heif/_version.py
@@ -1,3 +1,3 @@
 """Version of pillow_heif/pi_heif."""
 
-__version__ = "0.18.0"
+__version__ = "0.19.0.dev0"

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -105,7 +105,7 @@ def test_full_build():
     assert info["HEIF"]
     assert info["encoders"]
     assert info["decoders"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.18.1")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.18.2")
     if expected_version:
         assert info["libheif"] == expected_version
 
@@ -116,7 +116,7 @@ def test_light_build():
     assert not info["AVIF"]
     assert not info["HEIF"]
     assert info["decoders"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.18.1")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.18.2")
     if expected_version:
         assert info["libheif"] == expected_version
 


### PR DESCRIPTION
Nothing special changes  in this `libheif` version for pillow-heif.
