### PR TITLE
Add support for parsing auxiliary images

### DIFF
--- a/pillow_heif/__init__.py
+++ b/pillow_heif/__init__.py
@@ -16,6 +16,7 @@ from .constants import (
     HeifTransferCharacteristics,
 )
 from .heif import (
+    HeifAuxImage,
     HeifDepthImage,
     HeifFile,
     HeifImage,

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -1309,6 +1309,18 @@ static PyObject* _CtxImage_get_aux_info(CtxImageObject* self, PyObject* arg_imag
     return metadata;
 }
 
+static PyObject* _CtxImage_get_aux_type(CtxImageObject* self, PyObject* arg_image_id) {
+    heif_item_id aux_image_id = (heif_item_id)PyLong_AsUnsignedLong(arg_image_id);
+    struct heif_image_handle* aux_handle;
+    if (check_error(heif_image_handle_get_auxiliary_image_handle(self->handle, aux_image_id, &aux_handle)))
+        return NULL;
+    PyObject* aux_type = _get_aux_type(aux_handle);
+    if (!aux_type)
+        return NULL;
+    heif_image_handle_release(aux_handle);
+    return aux_type;
+}
+
 /* =========== CtxImage Experimental Part ======== */
 
 static PyObject* _CtxImage_camera_intrinsic_matrix(CtxImageObject* self, void* closure) {
@@ -1380,6 +1392,7 @@ static struct PyGetSetDef _CtxImage_getseters[] = {
 static struct PyMethodDef _CtxImage_methods[] = {
     {"get_aux_image", (PyCFunction)_CtxImage_get_aux_image, METH_O},
     {"get_aux_info", (PyCFunction)_CtxImage_get_aux_info, METH_O},
+    {"get_aux_type", (PyCFunction)_CtxImage_get_aux_type, METH_O},
     {NULL, NULL}
 };
 

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -1299,7 +1299,7 @@ static PyObject* _CtxImage_get_aux_info(CtxImageObject* self, PyObject* arg_imag
     PyObject* aux_type = _get_aux_type(aux_handle);
     if (!aux_type)
         return NULL;
-    __PyDict_SetItemString(metadata, "type", aux_type);
+    __PyDict_SetItemString(metadata, "aux_type", aux_type);
     PyObject* luma_bits = PyLong_FromLong(heif_image_handle_get_luma_bits_per_pixel(aux_handle));
     __PyDict_SetItemString(metadata, "bit_depth", luma_bits);
     PyObject* colorspace = _get_aux_colorspace(aux_handle);

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -759,6 +759,7 @@ PyObject* _CtxAuxImage(struct heif_image_handle* main_handle, heif_item_id aux_i
     enum heif_colorspace colorspace;
     enum heif_chroma chroma;
     if (check_error(heif_image_handle_get_preferred_decoding_colorspace(aux_handle, &colorspace, &chroma))) {
+        heif_image_handle_release(aux_handle);
         return NULL;
     }
     if (luma_bits != 8 || colorspace != heif_colorspace_monochrome) {
@@ -768,6 +769,7 @@ PyObject* _CtxAuxImage(struct heif_image_handle* main_handle, heif_item_id aux_i
             "Only 8-bit monochrome auxiliary images are currently supported. Got %d-bit %s image. "
             "Please consider filing an issue with an example HEIF file.",
             luma_bits, colorspace_str);
+        heif_image_handle_release(aux_handle);
         return NULL;
     }
     CtxImageObject *ctx_image = PyObject_New(CtxImageObject, &CtxImage_Type);

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -226,6 +226,8 @@ def __options_update(**kwargs):
             options.THUMBNAILS = v
         elif k == "depth_images":
             options.DEPTH_IMAGES = v
+        elif k == "aux_images":
+            options.AUX_IMAGES = v
         elif k == "quality":
             options.QUALITY = v
         elif k == "save_to_12bit":

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -154,7 +154,7 @@ class HeifImage(BaseImage):
         _depth_images: list[HeifDepthImage | None] = (
             [HeifDepthImage(i) for i in c_image.depth_image_list if i is not None] if options.DEPTH_IMAGES else []
         )
-        _ctx_aux_meta = {aux_id: c_image.get_aux_metadata(aux_id) for aux_id in c_image.aux_image_ids}
+        _ctx_aux_info = {aux_id: c_image.get_aux_info(aux_id) for aux_id in c_image.aux_image_ids}
         self.info = {
             "primary": bool(c_image.primary),
             "bit_depth": int(c_image.bit_depth),
@@ -162,7 +162,7 @@ class HeifImage(BaseImage):
             "metadata": _metadata,
             "thumbnails": _thumbnails,
             "depth_images": _depth_images,
-            "aux": _ctx_aux_meta,
+            "aux": _ctx_aux_info,
         }
         _heif_meta = _get_heif_meta(c_image)
         if _xmp:
@@ -215,7 +215,7 @@ class HeifImage(BaseImage):
 
         :returns: a :py:class:`~pillow_heif.HeifAuxImage` class instance.
         """
-        aux_info = self._c_image.get_aux_metadata(aux_id)
+        aux_info = self._c_image.get_aux_info(aux_id)
         if aux_info["colorspace"] is None:
             raise RuntimeError("Error while getting auxiliary information.")
         colorspace, bit_depth = aux_info["colorspace"], aux_info["bit_depth"]

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -154,7 +154,6 @@ class HeifImage(BaseImage):
         _depth_images: list[HeifDepthImage | None] = (
             [HeifDepthImage(i) for i in c_image.depth_image_list if i is not None] if options.DEPTH_IMAGES else []
         )
-        _ctx_aux_info = {aux_id: c_image.get_aux_info(aux_id) for aux_id in c_image.aux_image_ids}
         self.info = {
             "primary": bool(c_image.primary),
             "bit_depth": int(c_image.bit_depth),
@@ -162,8 +161,15 @@ class HeifImage(BaseImage):
             "metadata": _metadata,
             "thumbnails": _thumbnails,
             "depth_images": _depth_images,
-            "aux": _ctx_aux_info,
         }
+        if options.AUX_IMAGES:
+            _ctx_aux_info = {}
+            for aux_id in c_image.aux_image_ids:
+                aux_type = c_image.get_aux_type(aux_id)
+                if aux_type not in _ctx_aux_info:
+                    _ctx_aux_info[aux_type] = []
+                _ctx_aux_info[aux_type].append(aux_id)
+            self.info["aux"] = _ctx_aux_info
         _heif_meta = _get_heif_meta(c_image)
         if _xmp:
             self.info["xmp"] = _xmp

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -129,6 +129,15 @@ class HeifDepthImage(BaseImage):
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.size[0]}x{self.size[1]} {self.mode}>"
 
+    def to_pillow(self) -> Image.Image:
+        """Helper method to create :external:py:class:`~PIL.Image.Image` class.
+
+        :returns: :external:py:class:`~PIL.Image.Image` class created from an image.
+        """
+        image = super().to_pillow()
+        image.info = self.info.copy()
+        return image
+
 
 class HeifAuxImage(BaseImage):
     """Class representing the auxiliary image associated with the :py:class:`~pillow_heif.HeifImage` class."""
@@ -140,6 +149,15 @@ class HeifAuxImage(BaseImage):
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.size[0]}x{self.size[1]} {self.mode}>"
+
+    def to_pillow(self) -> Image.Image:
+        """Helper method to create :external:py:class:`~PIL.Image.Image` class.
+
+        :returns: :external:py:class:`~PIL.Image.Image` class created from an image.
+        """
+        image = super().to_pillow()
+        image.info = self.info.copy()
+        return image
 
 
 class HeifImage(BaseImage):

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -142,9 +142,6 @@ class HeifDepthImage(BaseImage):
 class HeifAuxImage(BaseImage):
     """Class representing the auxiliary image associated with the :py:class:`~pillow_heif.HeifImage` class."""
 
-    def __init__(self, c_image):
-        super().__init__(c_image)
-
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.size[0]}x{self.size[1]} {self.mode}>"
 

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -216,7 +216,7 @@ class HeifImage(BaseImage):
         :returns: a :py:class:`~pillow_heif.HeifAuxImage` class instance.
         """
         aux_info = self._c_image.get_aux_metadata(aux_id)
-        if aux_info is None or aux_info["colorspace"] is None:
+        if aux_info["colorspace"] is None:
             raise RuntimeError("Error while getting auxiliary information.")
         colorspace, bit_depth = aux_info["colorspace"], aux_info["bit_depth"]
         if colorspace != "monochrome":
@@ -230,8 +230,6 @@ class HeifImage(BaseImage):
                 "Please consider filing an issue with an example HEIF file."
             )
         aux_image = self._c_image.get_aux_image(aux_id)
-        if aux_image is None:
-            raise RuntimeError("Error while decoding the auxiliary image.")
         return HeifAuxImage(aux_image, aux_info)
 
 

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -129,14 +129,6 @@ class HeifDepthImage(BaseImage):
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.size[0]}x{self.size[1]} {self.mode}>"
 
-    def to_pillow(self) -> Image.Image:
-        """Helper method to create :external:py:class:`~PIL.Image.Image` class.
-
-        :returns: :external:py:class:`~PIL.Image.Image` class created from an image.
-        """
-        image = super().to_pillow()
-        return image
-
 
 class HeifAuxImage(BaseImage):
     """Class representing the auxiliary image associated with the :py:class:`~pillow_heif.HeifImage` class."""
@@ -148,14 +140,6 @@ class HeifAuxImage(BaseImage):
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.size[0]}x{self.size[1]} {self.mode}>"
-
-    def to_pillow(self) -> Image.Image:
-        """Helper method to create :external:py:class:`~PIL.Image.Image` class.
-
-        :returns: :external:py:class:`~PIL.Image.Image` class created from an image.
-        """
-        image = super().to_pillow()
-        return image
 
 
 class HeifImage(BaseImage):
@@ -227,16 +211,24 @@ class HeifImage(BaseImage):
         return image
 
     def get_aux_image(self, aux_id: int) -> HeifAuxImage:
+        """Method to retrieve the auxiliary image at the given ID.
+
+        :returns: a :py:class:`~pillow_heif.HeifAuxImage` class instance.
+        """
         aux_info = self._c_image.get_aux_metadata(aux_id)
         if aux_info is None or aux_info["colorspace"] is None:
             raise RuntimeError("Error while getting auxiliary information.")
         colorspace, bit_depth = aux_info["colorspace"], aux_info["bit_depth"]
         if colorspace != "monochrome":
-            raise NotImplementedError(f"{colorspace} color space is not supported for auxiliary images at the moment. "
-                                      "Please file an issue with an example HEIF file.")
+            raise NotImplementedError(
+                f"{colorspace} color space is not supported for auxiliary images at the moment. "
+                "Please consider filing an issue with an example HEIF file."
+            )
         if bit_depth != 8:
-            raise NotImplementedError(f"{bit_depth}-bit auxiliary images are not supported at the moment. "
-                                      "Please file an issue with an example HEIF file.")
+            raise NotImplementedError(
+                f"{bit_depth}-bit auxiliary images are not supported at the moment. "
+                "Please consider filing an issue with an example HEIF file."
+            )
         aux_image = self._c_image.get_aux_image(aux_id)
         if aux_image is None:
             raise RuntimeError("Error while decoding the auxiliary image.")

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -142,22 +142,11 @@ class HeifDepthImage(BaseImage):
 class HeifAuxImage(BaseImage):
     """Class representing the auxiliary image associated with the :py:class:`~pillow_heif.HeifImage` class."""
 
-    def __init__(self, c_image, info):
+    def __init__(self, c_image):
         super().__init__(c_image)
-        self.info = info
-        save_colorspace_chroma(c_image, self.info)
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.size[0]}x{self.size[1]} {self.mode}>"
-
-    def to_pillow(self) -> Image.Image:
-        """Helper method to create :external:py:class:`~PIL.Image.Image` class.
-
-        :returns: :external:py:class:`~PIL.Image.Image` class created from an image.
-        """
-        image = super().to_pillow()
-        image.info = self.info.copy()
-        return image
 
 
 class HeifImage(BaseImage):
@@ -239,22 +228,8 @@ class HeifImage(BaseImage):
 
         :returns: a :py:class:`~pillow_heif.HeifAuxImage` class instance.
         """
-        aux_info = self._c_image.get_aux_info(aux_id)
-        if aux_info["colorspace"] is None:
-            raise RuntimeError("Error while getting auxiliary information.")
-        colorspace, bit_depth = aux_info["colorspace"], aux_info["bit_depth"]
-        if colorspace != "monochrome":
-            raise NotImplementedError(
-                f"{colorspace} color space is not supported for auxiliary images at the moment. "
-                "Please consider filing an issue with an example HEIF file."
-            )
-        if bit_depth != 8:
-            raise NotImplementedError(
-                f"{bit_depth}-bit auxiliary images are not supported at the moment. "
-                "Please consider filing an issue with an example HEIF file."
-            )
         aux_image = self._c_image.get_aux_image(aux_id)
-        return HeifAuxImage(aux_image, aux_info)
+        return HeifAuxImage(aux_image)
 
 
 class HeifFile:

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -143,9 +143,8 @@ class HeifAuxImage(BaseImage):
 
     def __init__(self, c_image):
         super().__init__(c_image)
-        _image_type = c_image.aux_image_type
         self.info = {
-            "aux_image_type": _image_type,
+            "aux_type": c_image.aux_type,
         }
         save_colorspace_chroma(c_image, self.info)
 
@@ -173,8 +172,9 @@ class HeifImage(BaseImage):
         _depth_images: list[HeifDepthImage | None] = (
             [HeifDepthImage(i) for i in c_image.depth_image_list if i is not None] if options.DEPTH_IMAGES else []
         )
+        _ctx_aux_images = [c_image.get_aux_image(aux_id) for aux_id in c_image.aux_image_ids]
         _aux_images: list[HeifAuxImage | None] = (
-            [HeifAuxImage(i) for i in c_image.aux_image_list if i is not None]  # if options.AUX_IMAGES else []
+            [HeifAuxImage(img) for img in _ctx_aux_images if img is not None]  # if options.AUX_IMAGES else []
         )
         _heif_meta = _get_heif_meta(c_image)
         self.info = {
@@ -184,7 +184,7 @@ class HeifImage(BaseImage):
             "metadata": _metadata,
             "thumbnails": _thumbnails,
             "depth_images": _depth_images,
-            "aux_images": _aux_images,
+            "aux": _aux_images,
         }
         if _xmp:
             self.info["xmp"] = _xmp

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -226,13 +226,20 @@ class HeifImage(BaseImage):
         image.info["original_orientation"] = set_orientation(image.info)
         return image
 
-    def get_aux_image(self, aux_id: int) -> HeifAuxImage | None:
+    def get_aux_image(self, aux_id: int) -> HeifAuxImage:
         aux_info = self._c_image.get_aux_metadata(aux_id)
-        if aux_info is None:
-            return None
+        if aux_info is None or aux_info["colorspace"] is None:
+            raise RuntimeError("Error while getting auxiliary information.")
+        colorspace, bit_depth = aux_info["colorspace"], aux_info["bit_depth"]
+        if colorspace != "monochrome":
+            raise NotImplementedError(f"{colorspace} color space is not supported for auxiliary images at the moment. "
+                                      "Please file an issue with an example HEIF file.")
+        if bit_depth != 8:
+            raise NotImplementedError(f"{bit_depth}-bit auxiliary images are not supported at the moment. "
+                                      "Please file an issue with an example HEIF file.")
         aux_image = self._c_image.get_aux_image(aux_id)
         if aux_image is None:
-            return None
+            raise RuntimeError("Error while decoding the auxiliary image.")
         return HeifAuxImage(aux_image, aux_info)
 
 

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -127,7 +127,6 @@ class HeifDepthImage(BaseImage):
         save_colorspace_chroma(c_image, self.info)
 
     def __repr__(self):
-        _bytes = f"{len(self.data)} bytes" if self._data or isinstance(self._c_image, MimCImage) else "no"
         return f"<{self.__class__.__name__} {self.size[0]}x{self.size[1]} {self.mode}>"
 
     def to_pillow(self) -> Image.Image:
@@ -136,7 +135,6 @@ class HeifDepthImage(BaseImage):
         :returns: :external:py:class:`~PIL.Image.Image` class created from an image.
         """
         image = super().to_pillow()
-        image.info = self.info.copy()
         return image
 
 
@@ -152,7 +150,6 @@ class HeifAuxImage(BaseImage):
         save_colorspace_chroma(c_image, self.info)
 
     def __repr__(self):
-        _bytes = f"{len(self.data)} bytes" if self._data or isinstance(self._c_image, MimCImage) else "no"
         return f"<{self.__class__.__name__} {self.size[0]}x{self.size[1]} {self.mode}>"
 
     def to_pillow(self) -> Image.Image:
@@ -161,7 +158,6 @@ class HeifAuxImage(BaseImage):
         :returns: :external:py:class:`~PIL.Image.Image` class created from an image.
         """
         image = super().to_pillow()
-        image.info = self.info.copy()
         return image
 
 

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -478,6 +478,7 @@ class MimCImage:
         self.color_profile = None
         self.thumbnails: list[int] = []
         self.depth_image_list: list = []
+        self.aux_image_ids: list[int] = []
         self.primary = False
         self.chroma = HeifChroma.UNDEFINED.value
         self.colorspace = HeifColorspace.UNDEFINED.value

--- a/pillow_heif/options.py
+++ b/pillow_heif/options.py
@@ -18,6 +18,12 @@ DEPTH_IMAGES = True
 When use pillow_heif as a plugin you can set it with: `register_*_opener(depth_images=False)`"""
 
 
+AUX_IMAGES = True
+"""Option to enable/disable auxiliary image support
+
+When use pillow_heif as a plugin you can set it with: `register_*_opener(aux_images=False)`"""
+
+
 QUALITY = None
 """Default encoding quality
 

--- a/tests/options_test.py
+++ b/tests/options_test.py
@@ -32,6 +32,7 @@ def test_options_change_from_plugin_registering(register_opener):
             save_to_12bit=True,
             decode_threads=3,
             depth_images=False,
+            aux_images=False,
             save_nclx_profile=False,
             preferred_encoder={"HEIF": "id1", "AVIF": "id2"},
             preferred_decoder={"HEIF": "id3", "AVIF": "id4"},
@@ -41,6 +42,7 @@ def test_options_change_from_plugin_registering(register_opener):
         assert options.SAVE_HDR_TO_12_BIT
         assert options.DECODE_THREADS == 3
         assert options.DEPTH_IMAGES is False
+        assert options.AUX_IMAGES is False
         assert options.SAVE_NCLX_PROFILE is False
         assert options.PREFERRED_ENCODER == {"HEIF": "id1", "AVIF": "id2"}
         assert options.PREFERRED_DECODER == {"HEIF": "id3", "AVIF": "id4"}
@@ -50,6 +52,7 @@ def test_options_change_from_plugin_registering(register_opener):
         options.SAVE_HDR_TO_12_BIT = False
         options.DECODE_THREADS = 4
         options.DEPTH_IMAGES = True
+        options.AUX_IMAGES = True
         options.SAVE_NCLX_PROFILE = True
         options.PREFERRED_ENCODER = {"HEIF": "", "AVIF": ""}
         options.PREFERRED_DECODER = {"HEIF": "", "AVIF": ""}

--- a/tests/read_test.py
+++ b/tests/read_test.py
@@ -496,6 +496,19 @@ def test_depth_image():
     assert im_pil.info == depth_image.info
 
 
+def test_aux_image():
+    im = pillow_heif.open_heif("images/heif_other/pug.heic")
+    assert len(im.info["aux"]) == 1
+    assert "urn:com:apple:photo:2020:aux:hdrgainmap" in im.info["aux"]
+    assert len(im.info["aux"]["urn:com:apple:photo:2020:aux:hdrgainmap"]) == 1
+    aux_id = im.info["aux"]["urn:com:apple:photo:2020:aux:hdrgainmap"][0]
+    aux_image = im.get_aux_image(aux_id)
+    assert isinstance(aux_image, pillow_heif.HeifAuxImage)
+    aux_pil = aux_image.to_pillow()
+    assert aux_pil.size == (2016, 1512)
+    assert aux_pil.mode == "L"
+
+
 @pytest.mark.skipif(
     parse_version(pillow_heif.libheif_version()) < parse_version("1.18.0"), reason="requires LibHeif 1.18+"
 )


### PR DESCRIPTION
Fixes (partially) #117 .

Changes proposed in this pull request:

 * Added a property `aux_image_ids` to `CtxImage` that returns a list of non-depth non-alpha auxiliary image IDs.
 * Added a method `get_aux_type(aux_id)` to `CtxImage` that returns a string representing the `aux_type` of the given `aux_id`.
 * Added a key `aux` to `HeifImage.info` dict which is also a dict mapping from `aux_type` strings to a list of `aux_id`s.
 * Added a method `get_aux_image(aux_id)` to `CtxImage` that returns a `CtxImage` corresponding to the given `aux_id`.
 * Added a method `get_aux_image(aux_id)` to `HeifImage` which returns an instance of a new class `HeifAuxImage` wrapping the above `CtxImage`, after ensuring that the auxiliary image is 8-bit monochrome.
 * Added a method `get_aux_image(aux_id)` to `HeifFile` which calls the same method of the primary image.