### PR TITLE
Improve error handling in `_pillow_heif.c`

### DIFF
--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -959,7 +959,7 @@ static PyObject* _CtxImage_metadata(CtxImageObject* self, void* closure) {
         PyObject* meta_list = PyList_New(n_metas);
         if (!meta_list) {
             free(meta_ids);
-            return PyErr_NoMemory();
+            return NULL;
         }
 
         for (int i = 0; i < n_metas; i++) {
@@ -1030,7 +1030,7 @@ static PyObject* _CtxImage_thumbnails(CtxImageObject* self, void* closure) {
     PyObject* images_list = PyList_New(n_images);
     if (!images_list) {
         free(images_ids);
-        return PyList_New(0);
+        return NULL;
     }
 
     struct heif_image_handle* handle;
@@ -1166,7 +1166,7 @@ static PyObject* _CtxImage_depth_image_list(CtxImageObject* self, void* closure)
     PyObject* images_list = PyList_New(n_images);
     if (!images_list) {
         free(images_ids);
-        return PyErr_NoMemory();
+        return NULL;
     }
 
     for (int i = 0; i < n_images; i++) {
@@ -1344,7 +1344,7 @@ static PyObject* _load_file(PyObject* self, PyObject* args) {
     if (!images_list) {
         free(images_ids);
         heif_context_free(heif_ctx);
-        return PyErr_NoMemory();
+        return NULL;
     }
 
     enum heif_colorspace colorspace;


### PR DESCRIPTION
When I was working on #297, I noticed that functions that don't return `NULL` after setting error doesn't raise exception. But when an exception is later thrown, it causes Python to raise a `System Error` apparently because an exception was set earlier but was never thrown. This PR aims to fix some of these issues where returning `NULL` is more appropriate.

Disclaimer: I am not an expert in Python C-API. I'm still learning (and [have questions](https://stackoverflow.com/questions/79075466/how-to-dispose-off-a-partially-initialized-list-in-python-c-api)). So please review this carefully.