### PR TITLE
using `encoderinfo` for saving also for the non-primary images

### DIFF
--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -272,8 +272,7 @@ def _pil_encode_image(ctx: CtxEncode, img: Image.Image, primary: bool, **kwargs)
     _info = img.info.copy()
     _info["exif"] = _exif_from_pillow(img)
     _info["xmp"] = _xmp_from_pillow(img)
-    if primary:
-        _info.update(**kwargs)
+    _info.update(**kwargs)
     _info["primary"] = primary
     if img.mode == "YCbCr":
         ctx.add_image_ycbcr(img, image_orientation=_get_orientation_for_encoder(_info), **_info)


### PR DESCRIPTION
Fixes #308

I have no idea now why I originally wrote that this data was only transferred for the main image.

The change is small, in theory it shouldn't break anything, and in the future it will probably be necessary after a big refactoring (with Pillow 12?) to use `encoderinfo` for all these parameters, so the change is useful.
