### PR TITLE
use "files" instead of deprecated "file" in codecov action

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -81,7 +81,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
 
@@ -128,7 +128,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
 
@@ -167,7 +167,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
 
@@ -204,7 +204,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
 
@@ -288,7 +288,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
 
@@ -334,7 +334,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
 
@@ -403,6 +403,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
Removing such warning from CI:

`Unexpected input(s) 'file', valid inputs are ['base_sha', 'binary', 'codecov_yml_path', 'commit_parent', 'directory', 'disable_file_fixes', 'disable_search', 'disable_safe_directory', 'disable_telem', 'dry_run', 'env_vars', 'exclude', 'fail_ci_if_error', 'files', 'flags', 'force', 'git_service', 'gcov_args', 'gcov_executable', 'gcov_ignore', 'gcov_include', 'handle_no_reports_found', 'job_code', 'name', 'network_filter', 'network_prefix', 'os', 'override_branch', 'override_build', 'override_build_url', 'override_commit', 'override_pr', 'plugins', 'report_code', 'report_type', 'root_dir', 'run_command', 'skip_validation', 'slug', 'swift_project', 'token', 'url', 'use_legacy_upload_endpoint', 'use_oidc', 'use_pypi', 'verbose', 'version', 'working-directory']`