### PR TITLE
migration to "actions/upload-artifact@v4"

### DIFF
--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -35,16 +35,18 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Pillow-Heif sdist and wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: wheels_pillow_heif
           path: wheelhouse_pillow_heif
+          pattern: wheels_pillow_heif-*
+          merge-multiple: true
 
       - name: Pi-Heif sdist and wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: wheels_pi_heif
           path: wheelhouse_pi_heif
+          pattern: wheels_pi_heif-*
+          merge-multiple: true
 
       - name: Publish Pillow-Heif
         run: |

--- a/.github/workflows/wheels-pi_heif.yml
+++ b/.github/workflows/wheels-pi_heif.yml
@@ -40,9 +40,9 @@ jobs:
           python3 -m twine check wheelhouse/*
 
       - name: Upload built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pi_heif
+          name: wheels_pi_heif-macos-arm64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -100,9 +100,9 @@ jobs:
           python3 -m twine check wheelhouse/*
 
       - name: Upload built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pi_heif
+          name: wheels_pi_heif-windows-x86_64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -132,9 +132,9 @@ jobs:
           python3 -m twine check wheelhouse/*
 
       - name: Upload built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pi_heif
+          name: wheels_pi_heif-macos-x86_64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -175,13 +175,14 @@ jobs:
 
       - name: Checking built wheels
         run: |
+          python3 -m pip install "twine>=6.1.0" "packaging>=24.2"
           python3 -m pip install twine
           python3 -m twine check wheelhouse/*
 
       - name: Uploading wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pi_heif
+          name: wheels_pi_heif-${{ matrix.cibw_buildlinux }}-cpython-amd64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -222,13 +223,14 @@ jobs:
 
       - name: Checking built wheels
         run: |
+          python3 -m pip install "twine>=6.1.0" "packaging>=24.2"
           python3 -m pip install twine
           python3 -m twine check wheelhouse/*
 
       - name: Uploading wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pi_heif
+          name: wheels_pi_heif-${{ matrix.cibw_buildlinux }}-cpython-arm64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -251,6 +253,7 @@ jobs:
 
       - name: Run cibuildwheel
         run: |
+          python3 -m pip install "twine>=6.1.0" "packaging>=24.2"
           python3 -m pip install cibuildwheel==2.21.3
           python3 -m cibuildwheel
         env:
@@ -267,9 +270,9 @@ jobs:
           python3 -m twine check wheelhouse/*
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pi_heif
+          name: wheels_pi_heif-${{ matrix.cibw_buildlinux }}-pypy-amd64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -304,13 +307,14 @@ jobs:
 
       - name: Checking built wheels
         run: |
+          python3 -m pip install "twine>=6.1.0" "packaging>=24.2"
           python3 -m pip install twine
           python3 -m twine check wheelhouse/*
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pi_heif
+          name: wheels_pi_heif-${{ matrix.cibw_buildlinux }}-pypy-arm64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -352,7 +356,7 @@ jobs:
           python3 -m pytest
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pi_heif
+          name: wheels_pi_heif-sdist
           path: wheelhouse/*.tar.gz

--- a/.github/workflows/wheels-pillow_heif.yml
+++ b/.github/workflows/wheels-pillow_heif.yml
@@ -34,9 +34,9 @@ jobs:
           python3 -m twine check wheelhouse/*
 
       - name: Upload built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pillow_heif
+          name: wheels_pillow_heif-macos-arm64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -92,9 +92,9 @@ jobs:
           python3 -m twine check wheelhouse/*
 
       - name: Upload built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pillow_heif
+          name: wheels_pillow_heif-windows-x86_64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -119,9 +119,9 @@ jobs:
           python3 -m twine check wheelhouse/*
 
       - name: Upload built wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pillow_heif
+          name: wheels_pillow_heif-macos-x86_64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -172,13 +172,14 @@ jobs:
 
       - name: Checking built wheels
         run: |
+          python3 -m pip install "twine>=6.1.0" "packaging>=24.2"
           python3 -m pip install twine
           python3 -m twine check wheelhouse/*
 
       - name: Uploading wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pillow_heif
+          name: wheels_pillow_heif-${{ matrix.cibw_buildlinux }}-cpython-amd64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -232,13 +233,14 @@ jobs:
 
       - name: Checking built wheels
         run: |
+          python3 -m pip install "twine>=6.1.0" "packaging>=24.2"
           python3 -m pip install twine
           python3 -m twine check wheelhouse/*
 
       - name: Uploading wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pillow_heif
+          name: wheels_pillow_heif-${{ matrix.cibw_buildlinux }}-cpython-arm64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -281,13 +283,14 @@ jobs:
 
       - name: Checking built wheels
         run: |
+          python3 -m pip install "twine>=6.1.0" "packaging>=24.2"
           python3 -m pip install twine
           python3 -m twine check wheelhouse/*
 
       - name: Uploading wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pillow_heif
+          name: wheels_pillow_heif-${{ matrix.cibw_buildlinux }}-pypy-amd64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -329,13 +332,14 @@ jobs:
 
       - name: Checking built wheels
         run: |
+          python3 -m pip install "twine>=6.1.0" "packaging>=24.2"
           python3 -m pip install twine
           python3 -m twine check wheelhouse/*
 
       - name: Uploading wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pillow_heif
+          name: wheels_pillow_heif-${{ matrix.cibw_buildlinux }}-pypy-arm64
           path: wheelhouse/*.whl
           if-no-files-found: error
 
@@ -378,7 +382,7 @@ jobs:
           python3 -m pytest
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels_pillow_heif
+          name: wheels_pillow_heif-sdist
           path: wheelhouse/*.tar.gz


### PR DESCRIPTION
Since February the old version of `actions/upload-artifact` **V3** does not work, so switched to the new one.

guide: https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md

