### PR TITLE
libheif 1.19.7

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -244,7 +244,7 @@ jobs:
           cp ${{ env.MSYS2_PREFIX }}/bin/libstdc++-6.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libsharpyuv-*.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libdav1d-*.dll $site_packages/
-          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/rav1e.dll $site_packages/
+          cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/librav1e.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libkvazaar-*.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libcryptopp.dll $site_packages/
           cp -ErrorAction SilentlyContinue ${{ env.MSYS2_PREFIX }}/bin/libjpeg-*.dll $site_packages/

--- a/libheif/linux_build_libs.py
+++ b/libheif/linux_build_libs.py
@@ -14,7 +14,7 @@ PH_LIGHT_VERSION = sys.maxsize <= 2**32 or getenv("PH_LIGHT_ACTION", "0") != "0"
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/get/0b75c44c10e605fe9e9ebed58f04a46271131827.tar.gz"
 LIBAOM_URL = "https://aomedia.googlesource.com/aom/+archive/v3.6.1.tar.gz"
 LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.0.15/libde265-1.0.15.tar.gz"
-LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.19.5/libheif-1.19.5.tar.gz"
+LIBHEIF_URL = "https://github.com/strukturag/libheif/releases/download/v1.19.7/libheif-1.19.7.tar.gz"
 
 
 def download_file(url: str, out_path: str) -> bool:

--- a/libheif/macos/libheif.rb
+++ b/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.19.5/libheif-1.19.5.tar.gz"
-  sha256 "d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf"
+  url "https://github.com/strukturag/libheif/releases/download/v1.19.7/libheif-1.19.7.tar.gz"
+  sha256 "161c042d2102665fcee3ded851c78a0eb5f2d4bfe39fba48ba6e588fd6e964f3"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10

--- a/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,13 +4,16 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.19.5
-pkgrel=1
+pkgver=1.19.7
+pkgrel=2
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/strukturag/libheif"
-license=('spdx:LGPL-3.0' 'spdx:MIT')
+msys2_references=(
+  "cpe: cpe:/a:struktur:libheif"
+)
+license=('spdx:LGPL-3.0 AND MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
@@ -20,7 +23,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-x265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf')
+sha256sums=('161c042d2102665fcee3ded851c78a0eb5f2d4bfe39fba48ba6e588fd6e964f3')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/pi-heif/libheif/macos/libheif.rb
+++ b/pi-heif/libheif/macos/libheif.rb
@@ -3,8 +3,8 @@
 class Libheif < Formula
   desc "ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
   homepage "https://www.libde265.org/"
-  url "https://github.com/strukturag/libheif/releases/download/v1.19.5/libheif-1.19.5.tar.gz"
-  sha256 "d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf"
+  url "https://github.com/strukturag/libheif/releases/download/v1.19.7/libheif-1.19.7.tar.gz"
+  sha256 "161c042d2102665fcee3ded851c78a0eb5f2d4bfe39fba48ba6e588fd6e964f3"
   license "LGPL-3.0-only"
   # Set current revision from what it was taken plus 10
   revision 10

--- a/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/pi-heif/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -4,13 +4,16 @@
 _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.19.5
-pkgrel=1
+pkgver=1.19.7
+pkgrel=2
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://github.com/strukturag/libheif"
-license=('spdx:LGPL-3.0' 'spdx:MIT')
+msys2_references=(
+  "cpe: cpe:/a:struktur:libheif"
+)
+license=('spdx:LGPL-3.0 AND MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-gdk-pixbuf2"
@@ -18,7 +21,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf')
+sha256sums=('161c042d2102665fcee3ded851c78a0eb5f2d4bfe39fba48ba6e588fd6e964f3')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -1471,11 +1471,6 @@ static PyObject* _load_file(PyObject* self, PyObject* args) {
     #if LIBHEIF_HAVE_VERSION(1,19,0)
     if (disable_security_limits) {
         heif_context_set_security_limits(heif_ctx, heif_get_disabled_security_limits());
-    } else {
-        // override libheif default value for max_memory_block_size from 512MB to 768MB
-        struct heif_security_limits* current_limits = heif_context_get_security_limits(heif_ctx);
-        current_limits->max_memory_block_size = 768 * 1024 * 1024;
-        heif_context_set_security_limits(heif_ctx, current_limits);
     }
     #endif
 

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -105,7 +105,7 @@ def test_full_build():
     assert info["HEIF"]
     assert info["encoders"]
     assert info["decoders"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.19.5")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.19.7")
     if expected_version:
         assert info["libheif"] == expected_version
 
@@ -116,7 +116,7 @@ def test_light_build():
     assert not info["AVIF"]
     assert not info["HEIF"]
     assert info["decoders"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.19.5")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.19.7")
     if expected_version:
         assert info["libheif"] == expected_version
 

--- a/tests/read_test.py
+++ b/tests/read_test.py
@@ -559,5 +559,14 @@ def test_dav1d_decoder():
         pillow_heif.options.PREFERRED_DECODER["AVIF"] = ""
 
 
+@pytest.mark.skipif(
+    parse_version(pillow_heif.libheif_version()) < parse_version("1.19.7"), reason="Requires libheif 1.19.7."
+)
 def test_200_megapixels():
-    pillow_heif.open_heif("images/heif_special/200MP.heic")
+    with pytest.raises(RuntimeError):
+        _ = pillow_heif.open_heif("images/heif_special/200MP.heic").data
+    try:
+        pillow_heif.options.DISABLE_SECURITY_LIMITS = True
+        _ = pillow_heif.open_heif("images/heif_special/200MP.heic").data
+    finally:
+        pillow_heif.options.DISABLE_SECURITY_LIMITS = False


### PR DESCRIPTION
Fixes #328

```python

@pytest.mark.skipif(
    parse_version(pillow_heif.libheif_version()) < parse_version("1.19.7"), reason="Requires libheif 1.19.7."
)
def test_200_megapixels():
    with pytest.raises(RuntimeError):
        _ = pillow_heif.open_heif("images/heif_special/200MP.heic").data
    try:
        pillow_heif.options.DISABLE_SECURITY_LIMITS = True
        _ = pillow_heif.open_heif("images/heif_special/200MP.heic").data
    finally:
        pillow_heif.options.DISABLE_SECURITY_LIMITS = False
```

With latest libheif this code works. 

You can now simply disable the limits and get the behavior that was in the old libhaves before "1.19" versions        