### PR TITLE
chore(CI): replace windows-2019 with windows-2022

### DIFF
--- a/.github/workflows/test-src-build-windows.yml
+++ b/.github/workflows/test-src-build-windows.yml
@@ -30,9 +30,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  full_windows_2019:
-    name: Windows:2019-x86_64
-    runs-on: windows-2019
+  full_windows_2022:
+    name: Windows:2022-x86_64
+    runs-on: windows-2022
     env:
       MSYS2_PREFIX: "C:/temp/msys64/mingw64"
       PH_FULL_ACTION: 1
@@ -78,9 +78,9 @@ jobs:
       - name: Perform tests
         run: python -m pytest
 
-  lite_windows_2019:
-    name: Windows:2019-x86_64(Pi-Heif)
-    runs-on: windows-2019
+  lite_windows_2022:
+    name: Windows:2022-x86_64(Pi-Heif)
+    runs-on: windows-2022
     env:
       MSYS2_PREFIX: "C:/temp/msys64/mingw64"
       PH_LIGHT_ACTION: 1

--- a/.github/workflows/test-wheels-pi_heif.yml
+++ b/.github/workflows/test-wheels-pi_heif.yml
@@ -108,8 +108,8 @@ jobs:
             -f docker/test_wheels.Dockerfile .
 
   windows-wheels:
-    name: Windows • 2019 • ${{ matrix.python-version }}
-    runs-on: windows-2019
+    name: Windows • 2022 • ${{ matrix.python-version }}
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -112,8 +112,8 @@ jobs:
             -f docker/test_wheels.Dockerfile .
 
   windows-wheels:
-    name: Windows • 2019 • ${{ matrix.python-version }}
-    runs-on: windows-2019
+    name: Windows • 2022 • ${{ matrix.python-version }}
+    runs-on: windows-2022
     strategy:
       matrix:
         python-version: ["pypy-3.10", "pypy-3.11", "3.9", "3.10", "3.11", "3.12", "3.13"]

--- a/.github/workflows/wheels-pi_heif.yml
+++ b/.github/workflows/wheels-pi_heif.yml
@@ -48,7 +48,7 @@ jobs:
 
   wheels_windows:
     name: windows • x86_64
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       MSYS2_PREFIX: "C:/temp/msys64/mingw64"
 

--- a/.github/workflows/wheels-pillow_heif.yml
+++ b/.github/workflows/wheels-pillow_heif.yml
@@ -42,7 +42,7 @@ jobs:
 
   wheels_windows:
     name: windows • x86_64
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       MSYS2_PREFIX: "C:/temp/msys64/mingw64"
 


### PR DESCRIPTION
reference: https://github.com/actions/runner-images/issues/12045