### PR TITLE
support macos13(Ventura)

### DIFF
--- a/.github/workflows/wheels-pi_heif.yml
+++ b/.github/workflows/wheels-pi_heif.yml
@@ -30,7 +30,7 @@ jobs:
         run: brew uninstall --force --ignore-dependencies imagemagick libheif x265 aom libde265
 
       - name: Install libheif
-        run: sudo PH_LIGHT_ACTION=1 python3 libheif/build_libs.py
+        run: sudo PH_LIGHT_ACTION=1 MACOSX_DEPLOYMENT_TARGET="11.0" python3 libheif/build_libs.py
 
       - name: Install dependencies for Pillow
         run: brew install libjpeg little-cms2
@@ -42,7 +42,7 @@ jobs:
         env:
           CIBW_ARCHS: "arm64"
           CIBW_ENVIRONMENT_MACOS: PH_LIGHT_ACTION=1
-          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
 
       - name: Check built wheels
         run: |

--- a/.github/workflows/wheels-pillow_heif.yml
+++ b/.github/workflows/wheels-pillow_heif.yml
@@ -24,7 +24,7 @@ jobs:
         run: brew uninstall --force --ignore-dependencies imagemagick libheif x265 aom libde265
 
       - name: Install libheif
-        run: sudo python3 libheif/build_libs.py
+        run: sudo MACOSX_DEPLOYMENT_TARGET="11.0" python3 libheif/build_libs.py
 
       - name: Install dependencies for Pillow
         run: brew install libjpeg little-cms2
@@ -36,7 +36,7 @@ jobs:
         env:
           CIBW_ARCHS: "arm64"
           CIBW_ENVIRONMENT_MACOS: PH_FULL_ACTION=1
-          MACOSX_DEPLOYMENT_TARGET: "14.0"
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
 
       - name: Check built wheels
         run: |


### PR DESCRIPTION
Should solve #275, although it's late - but this is more of a PR for the future, so that the same OS versions as in the original Pillow will be supported