### PR TITLE
feat: grid(tiled) image encoding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/test.yml'
+      - 'libheif/build_libs.py'
       - 'pillow_heif/*.*'
       - 'tests/**'
       - 'setup.*'
@@ -13,6 +14,7 @@ on:
     branches: [master]
     paths:
       - '.github/workflows/test.yml'
+      - 'libheif/build_libs.py'
       - 'pillow_heif/*.*'
       - 'tests/**'
       - 'setup.*'
@@ -27,6 +29,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # the aom decoder as a loadable plugin for `test_load_plugin`, the aom encoder for the AVIF grid tests
+  PH_LIBHEIF_CMAKE_ARGS: "-DENABLE_PLUGIN_LOADING=ON -DWITH_AOM_DECODER=ON -DWITH_AOM_DECODER_PLUGIN=ON -DWITH_AOM_ENCODER=ON"
+
 jobs:
   lint:
     runs-on: ubuntu-24.04
@@ -40,11 +46,24 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Restore dependencies cache
+        id: deps-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/ph-deps
+          key: deps-test-plugins-${{ hashFiles('libheif/build_libs.py', '.github/workflows/test.yml') }}
+
       - name: Install Libheif
         run: |
-          sudo add-apt-repository -y ppa:strukturag/libheif
-          sudo apt update
-          sudo apt -y install libheif-dev libwebp-dev
+          sudo apt update && sudo apt -y install nasm libaom-dev
+          sudo BUILD_DIR="${{ runner.temp }}/ph-deps" PH_LIBHEIF_CMAKE_ARGS="$PH_LIBHEIF_CMAKE_ARGS" python3 libheif/build_libs.py
+
+      - name: Save dependencies cache
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/ph-deps
+          key: deps-test-plugins-${{ hashFiles('libheif/build_libs.py', '.github/workflows/test.yml') }}
 
       - name: Install from source
         run: python3 -m pip install ".[dev]" wheel setuptools
@@ -66,17 +85,32 @@ jobs:
 
       - name: Prepare system
         run: |
-          sudo add-apt-repository -y ppa:strukturag/libheif
           sudo apt update
-          sudo apt -y install libheif-dev
-          sudo apt -y install zlib1g-dev libjpeg-dev liblcms2-dev libwebp-dev libfribidi-dev libharfbuzz-dev libffi-dev
+          sudo apt -y install nasm libaom-dev
+          sudo apt -y install zlib1g-dev libjpeg-dev liblcms2-dev libwebp-dev libfribidi-dev libharfbuzz-dev libffi-dev libavif-dev
+
+      - name: Restore dependencies cache
+        id: deps-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/ph-deps
+          key: deps-test-plugins-${{ hashFiles('libheif/build_libs.py', '.github/workflows/test.yml') }}
+
+      - name: Install Libheif
+        run: sudo BUILD_DIR="${{ runner.temp }}/ph-deps" PH_LIBHEIF_CMAKE_ARGS="$PH_LIBHEIF_CMAKE_ARGS" python3 libheif/build_libs.py
+
+      - name: Save dependencies cache
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/ph-deps
+          key: deps-test-plugins-${{ hashFiles('libheif/build_libs.py', '.github/workflows/test.yml') }}
 
       - name: Prepare libheif plugin for load test
         run: |
-          sudo apt -y remove libheif-plugin-aomdec libheif-plugin-aomenc || true
-          apt download libheif-plugin-aomdec
-          dpkg-deb -x libheif-plugin-aomdec*.deb plugin-root
-          echo "TEST_PLUGIN_LOAD=$(find "$PWD/plugin-root" -name '*.so' -print -quit)" >> "$GITHUB_ENV"
+          PLUGIN_SO=$(find /usr/lib -name "libheif-aomdec.so" -print -quit)
+          sudo mv "$PLUGIN_SO" "$GITHUB_WORKSPACE/"
+          echo "TEST_PLUGIN_LOAD=$GITHUB_WORKSPACE/libheif-aomdec.so" >> "$GITHUB_ENV"
 
       - name: Install from source
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Grid(tiled) image encoding: `options.GRID_TILE_SIZE` option, `tile_size` parameter for `save` and `grid_tile_size` parameter for `register_*_opener`. #317
+- `info["tiling"]` dictionary with the grid info for tiled images. #317
+- `PH_LIBHEIF_CMAKE_ARGS` environment variable for `build_libs.py` to pass extra `cmake` arguments to the libheif build.
 - Windows ARM64 wheels.
 
 ### Changed
 
+- Minimum required `libheif` version is `1.23.1`.
 - Releases are now tag-triggered and published to PyPI with attestations via Trusted Publishing. #432
 - `libheif` was updated from the `1.23.0` to `1.23.1` version. #445
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Features:
  * `EXIF`, `XMP`, `IPTC` read & write support.
  * Support of multiple images in one file and a `PrimaryImage` attribute.
  * Adding & removing `thumbnails`.
+ * Grid(tiled) image encoding, like Apple devices do.
  * Reading of `Depth Images`.
  * (beta) Reading of `Auxiliary Images` by [johncf](https://github.com/johncf)
  * Adding HEIF support to Pillow in one line of code as a plugin.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,25 +30,32 @@ Linux
     | Here is the
         `build script <https://github.com/bigcat88/pillow_heif/blob/master/libheif/build_libs.py>`_
         used to build ``libheif`` with its encoders and decoders for the wheels.
+    | Extra ``cmake`` arguments for the ``libheif`` build can be passed with the
+        ``PH_LIBHEIF_CMAKE_ARGS`` environment variable, they override the default ones,
+        e.g. ``PH_LIBHEIF_CMAKE_ARGS="-DWITH_KVAZAAR=ON" python3 libheif/build_libs.py``
     |
     | **And of course you can build your own libheif library with your preferred encoders and decoders and use what you like.**
 
 There is many different ways how to build it from source. Main requirements are:
-    * ``libheif`` should be version >= ``1.19.0``.
+    * ``libheif`` should be version >= ``1.23.1``.
     * ``x265`` should support 10 - 12 bit encoding(if you want to save in that bitness)
     * ``aom`` should be >= ``3.3.0`` version
     * ``libde265`` should be >= ``1.0.8`` version
 
 
+Distro packages are too old: even the ``strukturag`` PPA tops out at ``libheif`` ``1.19.x``,
+so build ``libheif`` from source first, e.g. with the build script from the source tree:
+
 On `Ubuntu`:
 
-| :bash:`sudo add-apt-repository ppa:strukturag/libheif`
 | :bash:`sudo apt update`
-| :bash:`sudo apt -y install libheif-dev`
+| :bash:`sudo apt -y install cmake nasm build-essential curl`
+| :bash:`sudo python3 libheif/build_libs.py`
 
-On `Alpine 19`:
+On `Alpine`:
 
-| :bash:`sudo apk add --no-cache libheif-dev`
+| :bash:`sudo apk add --no-cache cmake nasm build-base curl`
+| :bash:`sudo python3 libheif/build_libs.py`
 
 Now install Pillow-Heif with::
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -11,6 +11,7 @@ Options
 .. autodata:: pillow_heif.options.SAVE_NCLX_PROFILE
 .. autodata:: pillow_heif.options.PREFERRED_ENCODER
 .. autodata:: pillow_heif.options.PREFERRED_DECODER
+.. autodata:: pillow_heif.options.GRID_TILE_SIZE
 
 Example of use
 """"""""""""""

--- a/docs/reference/HeifImage.rst
+++ b/docs/reference/HeifImage.rst
@@ -72,6 +72,19 @@ HeifImage object
         List of :py:class:`~pillow_heif.heif.HeifDepthImage` if any present for image.
         Currently `libheif` does not support writing of them, only reading.
 
+    .. py:attribute:: info["tiling"]
+        :type: dict
+
+        Tiling information when the image is stored as a grid of tiles. Absent for non-tiled images.
+        All values are in the display space, the same as ``size``. Keys:
+
+            * `num_columns`: `int`
+            * `num_rows`: `int`
+            * `tile_width`: `int`
+            * `tile_height`: `int`
+            * `image_width`: `int`
+            * `image_height`: `int`
+
 .. autoclass:: pillow_heif.heif.BaseImage
     :show-inheritance:
     :inherited-members:

--- a/docs/reference/HeifImagePlugin.rst
+++ b/docs/reference/HeifImagePlugin.rst
@@ -24,7 +24,7 @@ HeifImageFile object
         Specific keys for this plugin that is always present are:
             exif, xmp, metadata, primary, bit_depth, thumbnails
         Optional there can be also such keys:
-            icc_profile, icc_profile_type, nclx_profile
+            icc_profile, icc_profile_type, nclx_profile, tiling
 
     .. py:method:: get_format_mimetype
 

--- a/libheif/build_libs.py
+++ b/libheif/build_libs.py
@@ -4,6 +4,8 @@ import platform
 from os import chdir, environ, getcwd, makedirs, mkdir, path, remove
 from platform import machine
 from re import IGNORECASE, MULTILINE, match, search
+from shlex import split
+from shutil import rmtree
 from subprocess import DEVNULL, PIPE, STDOUT, CalledProcessError, TimeoutExpired, run
 
 # 1
@@ -13,6 +15,9 @@ BUILD_DIR = environ.get("BUILD_DIR", "/tmp/ph_build_stuff")
 _IS_DARWIN = platform.system() == "Darwin"
 _DEFAULT_PREFIX = "/usr/local" if _IS_DARWIN else "/usr"
 INSTALL_DIR_LIBS = environ.get("INSTALL_DIR_LIBS", _DEFAULT_PREFIX)
+
+# Extra arguments for the libheif `cmake` configure step, they override the default ones.
+LIBHEIF_CMAKE_ARGS = environ.get("PH_LIBHEIF_CMAKE_ARGS", "")
 
 LIBX265_URL = "https://bitbucket.org/multicoreware/x265_git/downloads/x265_4.2.tar.gz"
 LIBDE265_URL = "https://github.com/strukturag/libde265/releases/download/v1.1.0/libde265-1.1.0.tar.gz"
@@ -140,8 +145,23 @@ def _linux_ldconfig():
         pass
 
 
+def _drop_stale_libheif_cache(lib_path: str, stamp_file: str) -> None:
+    if not path.isdir(lib_path):
+        return
+    stamp = ""
+    if path.isfile(stamp_file):
+        with open(stamp_file) as f:  # noqa
+            stamp = f.read()
+    if stamp != LIBHEIF_CMAKE_ARGS:
+        print(f"PH_LIBHEIF_CMAKE_ARGS changed, discarding cached {lib_path}", flush=True)
+        rmtree(lib_path)
+
+
 def build_lib(url: str, name: str):
     lib_path = path.join(BUILD_DIR, name)
+    stamp_file = path.join(lib_path, ".ph_cmake_args")
+    if name == "libheif":
+        _drop_stale_libheif_cache(lib_path, stamp_file)
     if path.isdir(lib_path):
         print(f"Cache found for {name}: {lib_path}", flush=True)
         chdir(path.join(lib_path, "build")) if name != "x265" else chdir(lib_path)
@@ -241,9 +261,21 @@ def build_lib(url: str, name: str):
                     "-DBUILD_TESTING=OFF".split()
                 )
                 cmake_args += ["-DWITH_X265=ON"]
+                # heifio and the libheif JPEG codec discover JPEG/PNG via `find_package`; disabling
+                # keeps the configured build tree independent of the host packages (the CI deps
+                # cache), unless the user requests them via PH_LIBHEIF_CMAKE_ARGS.
+                if "JPEG" not in LIBHEIF_CMAKE_ARGS:
+                    cmake_args += ["-DCMAKE_DISABLE_FIND_PACKAGE_JPEG=ON"]
+                if "PNG" not in LIBHEIF_CMAKE_ARGS and "EXAMPLES" not in LIBHEIF_CMAKE_ARGS:
+                    cmake_args += ["-DCMAKE_DISABLE_FIND_PACKAGE_PNG=ON"]
                 if not _IS_DARWIN and is_musllinux():
                     cmake_args += [f"-DCMAKE_INSTALL_LIBDIR={INSTALL_DIR_LIBS}/lib"]
+                if LIBHEIF_CMAKE_ARGS:  # the user args go last so they override the default ones
+                    cmake_args += split(LIBHEIF_CMAKE_ARGS)
         run(["cmake", *cmake_args], check=True)
+        if name == "libheif":
+            with open(stamp_file, "w") as f:  # noqa
+                f.write(LIBHEIF_CMAKE_ARGS)
         print(f"{name} configured. building...", flush=True)
         if name == "libheif":
             run("make -j4".split(), check=True)

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -2,9 +2,11 @@
 
 #include "Python.h"
 #include "libheif/heif.h"
-#if LIBHEIF_HAVE_VERSION(1,20,0)
-    #include "libheif/heif_properties.h"
+#if !LIBHEIF_HAVE_VERSION(1,23,1)
+    #error "pillow_heif requires libheif >= 1.23.1"
 #endif
+#include "libheif/heif_tiling.h"
+#include "libheif/heif_properties.h"
 #include "_ph_postprocess.h"
 
 /* =========== Free-threading support ======== */
@@ -71,6 +73,8 @@ typedef struct {
     struct heif_image* image;
     struct heif_image_handle* handle;
     struct heif_color_profile_nclx* output_nclx_color_profile;
+    uint32_t grid_columns;                  // zero for non-grid images
+    uint32_t grid_rows;                     // zero for non-grid images
 } CtxWriteImageObject;
 
 static PyTypeObject CtxWriteImage_Type;
@@ -140,6 +144,10 @@ static PyObject* _CtxWriteImage_add_plane(CtxWriteImageObject* self, PyObject* a
     Py_buffer buffer;
     uint8_t* plane_data;
 
+    if (!self->image) {
+        PyErr_SetString(PyExc_ValueError, "image has no pixel data");
+        return NULL;
+    }
     if (!PyArg_ParseTuple(args, "(ii)iiy*ii", &width, &height, &depth, &depth_in, &buffer, &bgr_mode, &stride_in))
         return NULL;
 
@@ -332,6 +340,10 @@ static PyObject* _CtxWriteImage_add_plane_la(CtxWriteImageObject* self, PyObject
     Py_buffer buffer;
     uint8_t *plane_data_y, *plane_data_alpha;
 
+    if (!self->image) {
+        PyErr_SetString(PyExc_ValueError, "image has no pixel data");
+        return NULL;
+    }
     if (!PyArg_ParseTuple(args, "(ii)iiy*i", &width, &height, &depth, &depth_in, &buffer, &stride_in))
         return NULL;
 
@@ -437,6 +449,10 @@ static PyObject* _CtxWriteImage_add_plane_l(CtxWriteImageObject* self, PyObject*
     Py_buffer buffer;
     uint8_t *plane_data;
 
+    if (!self->image) {
+        PyErr_SetString(PyExc_ValueError, "image has no pixel data");
+        return NULL;
+    }
     if (!PyArg_ParseTuple(args, "(ii)iiy*ii", &width, &height, &depth, &depth_in, &buffer, &stride_in, &target_heif_channel))
         return NULL;
 
@@ -505,6 +521,10 @@ static PyObject* _CtxWriteImage_set_icc_profile(CtxWriteImageObject* self, PyObj
     Py_buffer buffer;
     struct heif_error error;
 
+    if (!self->image) {
+        PyErr_SetString(PyExc_ValueError, "image has no pixel data");
+        return NULL;
+    }
     if (!PyArg_ParseTuple(args, "sy*", &type, &buffer))
         return NULL;
 
@@ -520,6 +540,10 @@ static PyObject* _CtxWriteImage_set_nclx_profile(CtxWriteImageObject* self, PyOb
     struct heif_error error;
     int color_primaries, transfer_characteristics, matrix_coefficients, full_range_flag;
 
+    if (!self->image) {
+        PyErr_SetString(PyExc_ValueError, "image has no pixel data");
+        return NULL;
+    }
     if (!PyArg_ParseTuple(args, "iiii",
         &color_primaries, &transfer_characteristics, &matrix_coefficients, &full_range_flag))
         return NULL;
@@ -540,7 +564,10 @@ static PyObject* _CtxWriteImage_set_pixel_aspect_ratio(CtxWriteImageObject* self
     unsigned int aspect_h, aspect_v;
     if (!PyArg_ParseTuple(args, "II", &aspect_h, &aspect_v))
         return NULL;
-    heif_image_set_pixel_aspect_ratio(self->image, aspect_h, aspect_v);
+    if (self->handle)
+        heif_image_handle_set_pixel_aspect_ratio(self->handle, aspect_h, aspect_v);
+    else
+        heif_image_set_pixel_aspect_ratio(self->image, aspect_h, aspect_v);
     Py_RETURN_NONE;
 }
 
@@ -552,6 +579,10 @@ static PyObject* _CtxWriteImage_encode(CtxWriteImageObject* self, PyObject* args
     struct heif_error error;
     struct heif_encoding_options* options;
 
+    if (!self->image) {
+        PyErr_SetString(PyExc_ValueError, "image has no pixel data");
+        return NULL;
+    }
     if (!PyArg_ParseTuple(args, "Oiiiiiii",
         (PyObject*)&ctx_write, &primary,
         &save_nclx, &color_primaries, &transfer_characteristics, &matrix_coefficients, &full_range_flag,
@@ -642,22 +673,33 @@ static PyObject* _CtxWriteImage_set_metadata(CtxWriteImageObject* self, PyObject
 }
 
 static PyObject* _CtxWriteImage_encode_thumbnail(CtxWriteImageObject* self, PyObject* args) {
-    /* ctx: CtxWriteObject, thumb_box: int */
+    /* ctx: CtxWriteObject, thumb_box: int, image_orientation: int, pixels: CtxWriteImage (for grid images) */
     struct heif_error error;
     struct heif_image_handle* thumb_handle;
     struct heif_encoding_options* options;
     CtxWriteObject* ctx_write;
+    CtxWriteImageObject* pixels_image = NULL;
+    struct heif_image* source_image;
     int thumb_box, image_orientation;
 
-    if (!PyArg_ParseTuple(args, "Oii", (PyObject*)&ctx_write, &thumb_box, &image_orientation))
+    if (!PyArg_ParseTuple(args, "Oii|O",
+        (PyObject*)&ctx_write, &thumb_box, &image_orientation, (PyObject*)&pixels_image))
         return NULL;
+
+    if ((PyObject*)pixels_image == Py_None)
+        pixels_image = NULL;
+    source_image = (pixels_image && pixels_image->image) ? pixels_image->image : self->image;
+    if (!source_image) {
+        PyErr_SetString(PyExc_ValueError, "no pixel data to encode thumbnail from");
+        return NULL;
+    }
 
     Py_BEGIN_ALLOW_THREADS
     options = heif_encoding_options_alloc();
     options->image_orientation = image_orientation;
     error = heif_context_encode_thumbnail(
         ctx_write->ctx,
-        self->image,
+        source_image,
         self->handle,
         ctx_write->encoder,
         options,
@@ -668,6 +710,17 @@ static PyObject* _CtxWriteImage_encode_thumbnail(CtxWriteImageObject* self, PyOb
     if (check_error(error))
         return NULL;
     heif_image_handle_release(thumb_handle);
+    Py_RETURN_NONE;
+}
+
+static PyObject* _CtxWriteImage_set_primary(CtxWriteImageObject* self, PyObject* args) {
+    CtxWriteObject* ctx_write;
+    if (!PyArg_ParseTuple(args, "O", (PyObject*)&ctx_write))
+        return NULL;
+    if (self->handle) {
+        if (check_error(heif_context_set_primary_image(ctx_write->ctx, self->handle)))
+            return NULL;
+    }
     Py_RETURN_NONE;
 }
 
@@ -683,6 +736,7 @@ static struct PyMethodDef _CtxWriteImage_methods[] = {
     {"set_xmp", (PyCFunction)_CtxWriteImage_set_xmp, METH_VARARGS},
     {"set_metadata", (PyCFunction)_CtxWriteImage_set_metadata, METH_VARARGS},
     {"encode_thumbnail", (PyCFunction)_CtxWriteImage_encode_thumbnail, METH_VARARGS},
+    {"set_primary", (PyCFunction)_CtxWriteImage_set_primary, METH_VARARGS},
     {NULL, NULL}
 };
 
@@ -734,7 +788,98 @@ static PyObject* _CtxWriteImage_create(CtxWriteObject* self, PyObject* args) {
     ctx_write_image->image = image;
     ctx_write_image->handle = NULL;
     ctx_write_image->output_nclx_color_profile = NULL;
+    ctx_write_image->grid_columns = 0;
+    ctx_write_image->grid_rows = 0;
     return (PyObject*)ctx_write_image;
+}
+
+static PyObject* _CtxWrite_create_grid(CtxWriteObject* self, PyObject* args) {
+    uint32_t image_width, image_height, tile_columns, tile_rows;
+    int save_nclx, color_primaries, transfer_characteristics, matrix_coefficients, full_range_flag, image_orientation;
+    struct heif_image_handle* grid_handle = NULL;
+    struct heif_encoding_options* enc_options;
+
+    if (!PyArg_ParseTuple(args, "IIIIiiiiii",
+        &image_width, &image_height, &tile_columns, &tile_rows,
+        &save_nclx, &color_primaries, &transfer_characteristics, &matrix_coefficients, &full_range_flag,
+        &image_orientation))
+        return NULL;
+
+    enc_options = heif_encoding_options_alloc();
+    enc_options->macOS_compatibility_workaround_no_nclx_profile = !save_nclx;
+    enc_options->image_orientation = image_orientation;
+    if (
+        (color_primaries != -1) ||
+        (transfer_characteristics != -1) ||
+        (matrix_coefficients != -1) ||
+        (full_range_flag != -1)
+       ) {
+        enc_options->output_nclx_profile = heif_nclx_color_profile_alloc();
+        if (color_primaries != -1)
+            enc_options->output_nclx_profile->color_primaries = color_primaries;
+        if (transfer_characteristics != -1)
+            enc_options->output_nclx_profile->transfer_characteristics = transfer_characteristics;
+        if (matrix_coefficients != -1)
+            enc_options->output_nclx_profile->matrix_coefficients = matrix_coefficients;
+        if (full_range_flag != -1)
+            enc_options->output_nclx_profile->full_range_flag = full_range_flag;
+    }
+    struct heif_color_profile_nclx* nclx_to_keep = enc_options->output_nclx_profile;
+    struct heif_error error = heif_context_add_grid_image(
+        self->ctx, image_width, image_height, tile_columns, tile_rows, enc_options, &grid_handle);
+    heif_encoding_options_free(enc_options);
+    if (check_error(error)) {
+        if (nclx_to_keep)
+            heif_nclx_color_profile_free(nclx_to_keep);
+        return NULL;
+    }
+
+    CtxWriteImageObject* grid_obj = PyObject_New(CtxWriteImageObject, &CtxWriteImage_Type);
+    if (!grid_obj) {
+        heif_image_handle_release(grid_handle);
+        if (nclx_to_keep)
+            heif_nclx_color_profile_free(nclx_to_keep);
+        return NULL;
+    }
+    grid_obj->chroma = 0;
+    grid_obj->image = NULL;
+    grid_obj->handle = grid_handle;
+    grid_obj->output_nclx_color_profile = nclx_to_keep;
+    grid_obj->grid_columns = tile_columns;
+    grid_obj->grid_rows = tile_rows;
+    return (PyObject*)grid_obj;
+}
+
+static PyObject* _CtxWrite_add_tile(CtxWriteObject* self, PyObject* args) {
+    CtxWriteImageObject *grid_image, *tile_image;
+    uint32_t tile_x, tile_y;
+
+    if (!PyArg_ParseTuple(args, "OIIO",
+        (PyObject*)&grid_image, &tile_x, &tile_y, (PyObject*)&tile_image))
+        return NULL;
+
+    if (!grid_image->handle) {
+        PyErr_SetString(PyExc_ValueError, "grid image has no handle");
+        return NULL;
+    }
+    if (!tile_image->image) {
+        PyErr_SetString(PyExc_ValueError, "tile image has no image data");
+        return NULL;
+    }
+    if (tile_x >= grid_image->grid_columns || tile_y >= grid_image->grid_rows) {
+        PyErr_SetString(PyExc_ValueError, "tile position is out of the grid bounds");
+        return NULL;
+    }
+
+    struct heif_error error;
+    Py_BEGIN_ALLOW_THREADS
+    error = heif_context_add_image_tile(
+        self->ctx, grid_image->handle, tile_x, tile_y, tile_image->image, self->encoder);
+    Py_END_ALLOW_THREADS
+    if (check_error(error))
+        return NULL;
+
+    Py_RETURN_NONE;
 }
 
 static PyObject* _CtxWrite_finalize(CtxWriteObject* self) {
@@ -751,6 +896,8 @@ static PyObject* _CtxWrite_finalize(CtxWriteObject* self) {
 static struct PyMethodDef _CtxWrite_methods[] = {
     {"set_parameter", (PyCFunction)_CtxWrite_set_parameter, METH_VARARGS},
     {"create_image", (PyCFunction)_CtxWriteImage_create, METH_VARARGS},
+    {"create_grid", (PyCFunction)_CtxWrite_create_grid, METH_VARARGS},
+    {"add_tile", (PyCFunction)_CtxWrite_add_tile, METH_VARARGS},
     {"finalize", (PyCFunction)_CtxWrite_finalize, METH_NOARGS},
     {NULL, NULL}
 };
@@ -1385,6 +1532,23 @@ static PyObject* _CtxImage_pixel_aspect_ratio(CtxImageObject* self, void* closur
     Py_RETURN_NONE;
 }
 
+static PyObject* _CtxImage_tiling(CtxImageObject* self, void* closure) {
+    struct heif_image_tiling tiling;
+    /* process_image_transformations=1: report display space values, like all other dimensions we expose */
+    struct heif_error error = heif_image_handle_get_image_tiling(self->handle, 1, &tiling);
+    if (error.code != heif_error_Ok || (tiling.num_columns <= 1 && tiling.num_rows <= 1)) {
+        Py_RETURN_NONE;
+    }
+    return Py_BuildValue("{sIsIsIsIsIsI}",
+        "num_columns", tiling.num_columns,
+        "num_rows", tiling.num_rows,
+        "tile_width", tiling.tile_width,
+        "tile_height", tiling.tile_height,
+        "image_width", tiling.image_width,
+        "image_height", tiling.image_height
+    );
+}
+
 /* =========== CtxImage Experimental Part ======== */
 
 static PyObject* _CtxImage_camera_intrinsic_matrix(CtxImageObject* self, void* closure) {
@@ -1443,6 +1607,7 @@ static struct PyGetSetDef _CtxImage_getseters[] = {
     {"pixel_aspect_ratio", (getter)_CtxImage_pixel_aspect_ratio, NULL, NULL, NULL},
     {"camera_intrinsic_matrix", (getter)_CtxImage_camera_intrinsic_matrix, NULL, NULL, NULL},
     {"camera_extrinsic_matrix_rot", (getter)_CtxImage_camera_extrinsic_matrix_rot, NULL, NULL, NULL},
+    {"tiling", (getter)_CtxImage_tiling, NULL, NULL, NULL},
     {NULL, NULL, NULL, NULL, NULL}
 };
 

--- a/pillow_heif/_version.py
+++ b/pillow_heif/_version.py
@@ -1,3 +1,3 @@
 """Version of pillow_heif."""
 
-__version__ = "1.4.0"
+__version__ = "1.5.0.dev0"

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -177,6 +177,8 @@ def __options_update(**kwargs):
             options.PREFERRED_ENCODER = v
         elif k == "preferred_decoder":
             options.PREFERRED_DECODER = v
+        elif k == "grid_tile_size":
+            options.GRID_TILE_SIZE = v
         else:
             warn(f"Unknown option: {k}", stacklevel=1)
 

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -185,6 +185,9 @@ class HeifImage(BaseImage):
         pixel_aspect_ratio = c_image.pixel_aspect_ratio
         if pixel_aspect_ratio:
             self.info["pixel_aspect_ratio"] = pixel_aspect_ratio
+        tiling = c_image.tiling
+        if tiling:
+            self.info["tiling"] = tiling
         save_colorspace_chroma(c_image, self.info)
         color_profile: dict[str, Any] = c_image.color_profile
         if color_profile:
@@ -388,6 +391,8 @@ class HeifFile:
 
             ``full_range_flag`` - nclx profile: full range flag, default: 1
 
+            ``tile_size`` - int, see :py:attr:`~pillow_heif.options.GRID_TILE_SIZE`
+
         :param fp: A filename (string), pathlib.Path object or an object with `write` method.
         """
         _encode_images(self._images, fp, **kwargs)
@@ -468,7 +473,7 @@ class HeifFile:
             img.size,
             img.tobytes(),
         )
-        for key in ["bit_depth", "thumbnails", "icc_profile", "icc_profile_type", "pixel_aspect_ratio"]:
+        for key in ["bit_depth", "thumbnails", "icc_profile", "icc_profile_type", "pixel_aspect_ratio", "tiling"]:
             if key in image.info:
                 added_image.info[key] = image.info[key]
         for key in ["nclx_profile", "metadata"]:
@@ -605,10 +610,13 @@ def _encode_images(images: list[HeifImage], fp, **kwargs) -> None:
         raise ValueError("Cannot write file with no images as HEIF.")
     primary_index = _get_primary_index(images_to_save, kwargs.get("primary_index"))
     ctx_write = CtxEncode(compression_format, **kwargs)
+    tile_size = kwargs.pop("tile_size", None)
     for i, img in enumerate(images_to_save):
         img.load()
         info = img.info.copy()
         info["primary"] = False
+        if tile_size is not None:  # `tile_size` is not per-image metadata, it applies to all images
+            info["tile_size"] = tile_size
         if i == primary_index:
             info.update(**kwargs)
             info["primary"] = True

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -83,6 +83,10 @@ LIBHEIF_CHROMA_MAP = {
     3: 444,
 }
 
+MAX_ITEMS_ERROR = (
+    "File with grid images cannot have more than 1000 items (tiles, thumbnails, metadata), increase `tile_size`."
+)
+
 
 def save_colorspace_chroma(c_image, info: dict) -> None:
     """Converts `chroma` value from `c_image` to useful values and stores them in ``info`` dict."""
@@ -350,6 +354,80 @@ def _get_heif_meta(c_image) -> dict:
     return r
 
 
+def _extract_tile(
+    data, src_stride: int, bytes_per_pixel: int, tile_box: tuple[int, int, int, int], tile_wh: int
+) -> bytes:
+    x, y, w, h = tile_box
+    tile_stride = tile_wh * bytes_per_pixel
+    tile_data = bytearray(tile_stride * tile_wh)
+    src_row_bytes = w * bytes_per_pixel
+    for row in range(h):
+        src_offset = (y + row) * src_stride + x * bytes_per_pixel
+        dst_offset = row * tile_stride
+        tile_data[dst_offset : dst_offset + src_row_bytes] = data[src_offset : src_offset + src_row_bytes]
+        if w < tile_wh:  # replicate the edge pixel, padding with zeros bleeds into the image via chroma subsampling
+            edge_pixel = tile_data[dst_offset + src_row_bytes - bytes_per_pixel : dst_offset + src_row_bytes]
+            tile_data[dst_offset + src_row_bytes : dst_offset + tile_stride] = edge_pixel * (tile_wh - w)
+    if h < tile_wh:
+        edge_row = tile_data[(h - 1) * tile_stride : h * tile_stride]
+        for row in range(h, tile_wh):
+            tile_data[row * tile_stride : (row + 1) * tile_stride] = edge_row
+    return bytes(tile_data)
+
+
+def _add_planes(  # pylint: disable=too-many-arguments disable=too-many-positional-arguments
+    im_out, size: tuple[int, int], mode: str, data, stride: int, bit_depth_out: int
+) -> None:
+    bit_depth_in = MODE_INFO[mode][1]
+    if MODE_INFO[mode][0] == 1:
+        im_out.add_plane_l(size, bit_depth_out, bit_depth_in, data, stride, HeifChannel.CHANNEL_Y)
+    elif MODE_INFO[mode][0] == 2:
+        im_out.add_plane_la(size, bit_depth_out, bit_depth_in, data, stride)
+    else:
+        im_out.add_plane(size, bit_depth_out, bit_depth_in, data, mode.find("BGR") != -1, stride)
+
+
+def _output_bit_depth(mode: str, **kwargs) -> int:
+    bit_depth_out = 8 if MODE_INFO[mode][1] == 8 else kwargs.get("bit_depth", 16)
+    if bit_depth_out == 16:
+        bit_depth_out = 12 if options.SAVE_HDR_TO_12_BIT else 10
+    return bit_depth_out
+
+
+def _items_per_image(mode: str) -> int:
+    return 2 if mode.split(sep=";")[0][-1] in ("A", "a") else 1  # the alpha plane is stored as a separate item
+
+
+def _output_nclx_params(kwargs: dict, nclx_profile=None) -> tuple[int, int, int, int]:
+    nclx_keys = ("color_primaries", "transfer_characteristics", "matrix_coefficients", "full_range_flag")
+    save_nclx = kwargs.get("save_nclx_profile", options.SAVE_NCLX_PROFILE)
+    has_explicit_nclx = any(k in kwargs for k in nclx_keys)
+    if save_nclx and nclx_profile and not has_explicit_nclx:
+        return (
+            nclx_profile["color_primaries"],
+            nclx_profile["transfer_characteristics"],
+            nclx_profile["matrix_coefficients"],
+            nclx_profile["full_range_flag"],
+        )
+    # When NCLX saving is enabled and no existing NCLX profile is on the image and no explicit NCLX parameters
+    # were provided, write an NCLX box that matches libheif internal sRGB encoding defaults.
+    # Without this, no NCLX box is written and viewers must guess the color space, which causes color shifts.
+    # See issue #365.
+    # Values match libheif nclx_profile::set_sRGB_defaults() exactly:
+    #   primaries=1 (BT.709)
+    #   transfer=13 (sRGB)
+    #   matrix=6 (BT.601-6)
+    #   full_range=1
+    if save_nclx and not kwargs.get("nclx_profile") and not has_explicit_nclx:
+        return 1, 13, 6, 1
+    return (
+        kwargs.get("color_primaries", -1),
+        kwargs.get("transfer_characteristics", -1),
+        kwargs.get("matrix_coefficients", -1),
+        kwargs.get("full_range_flag", -1),
+    )
+
+
 class CtxEncode:
     """Encoder bindings from python to python C module."""
 
@@ -370,37 +448,120 @@ class CtxEncode:
             enc_params["chroma"] = chroma
         for key, value in enc_params.items():
             self.ctx_write.set_parameter(key, value if isinstance(value, str) else str(value))
+        self._compression_format = compression_format
+        self._chroma = str(enc_params.get("chroma", ""))
+        self._grid_images: list = []  # the `output_nclx_color_profile` of a grid must outlive `finalize`
+        self._items_count = 0
 
     def add_image(self, size: tuple[int, int], mode: str, data, **kwargs) -> None:
         """Adds image to the encoder."""
         if size[0] <= 0 or size[1] <= 0:
             raise ValueError("Empty images are not supported.")
-        bit_depth_in = MODE_INFO[mode][1]
-        bit_depth_out = 8 if bit_depth_in == 8 else kwargs.get("bit_depth", 16)
-        if bit_depth_out == 16:
-            bit_depth_out = 12 if options.SAVE_HDR_TO_12_BIT else 10
+        tile_size = kwargs.pop("tile_size", None)
+        if tile_size is None:  # for tiled images the grid structure is preserved during re-save by default
+            tile_size = (kwargs.get("tiling") or {}).get("tile_width", 0) or options.GRID_TILE_SIZE
+        if mode == "YCbCr" and tile_size > 0 and (size[0] > tile_size or size[1] > tile_size):
+            raise ValueError("Grid encoding is not supported for `YCbCr` mode images, set `tile_size=0`.")
+        # libheif stores alpha only on the individual tiles and attaches none to the grid item
+        # itself, so Apple's ImageIO renders tiled alpha images as fully opaque; it also cannot
+        # mark grid items as premultiplied. Images with an alpha channel are encoded as a single image.
+        has_alpha = mode.split(sep=";")[0][-1] in ("A", "a")
+        # MIAF (ISO/IEC 23000-22) requires grid tiles of at least 64 pixels and, with subsampled
+        # chroma, even image dimensions and tile offsets; libavif refuses to decode AVIF files
+        # violating this entirely, so such images are also encoded as a single image.
+        miaf_invalid = self._compression_format == HeifCompressionFormat.AV1 and (
+            tile_size < 64
+            or (MODE_INFO[mode][0] > 2 and self._chroma != "444" and (size[0] % 2 or size[1] % 2 or tile_size % 2))
+        )
+        if tile_size > 0 and not has_alpha and not miaf_invalid and (size[0] > tile_size or size[1] > tile_size):
+            self._add_image_grid(size, mode, data, tile_size, **kwargs)
+        else:
+            self._add_image_single(size, mode, data, **kwargs)
+
+    def _add_image_single(self, size: tuple[int, int], mode: str, data, **kwargs) -> None:
         premultiplied_alpha = int(mode.split(sep=";")[0][-1] == "a")
         # creating image
         im_out = self.ctx_write.create_image(size, MODE_INFO[mode][2], MODE_INFO[mode][3], premultiplied_alpha)
         # image data
-        if MODE_INFO[mode][0] == 1:
-            im_out.add_plane_l(size, bit_depth_out, bit_depth_in, data, kwargs.get("stride", 0), HeifChannel.CHANNEL_Y)
-        elif MODE_INFO[mode][0] == 2:
-            im_out.add_plane_la(size, bit_depth_out, bit_depth_in, data, kwargs.get("stride", 0))
-        else:
-            im_out.add_plane(size, bit_depth_out, bit_depth_in, data, mode.find("BGR") != -1, kwargs.get("stride", 0))
-        self._finish_add_image(im_out, size, **kwargs)
+        _add_planes(im_out, size, mode, data, kwargs.get("stride", 0), _output_bit_depth(mode, **kwargs))
+        self._finish_add_image(im_out, size, mode, **kwargs)
+
+    def _add_image_grid(self, size: tuple[int, int], mode: str, data, tile_size: int, **kwargs) -> None:
+        tile_columns = ceil(size[0] / tile_size)
+        tile_rows = ceil(size[1] / tile_size)
+        if tile_columns > 256 or tile_rows > 256:  # the ISO grid payload stores tile counts as uint8
+            raise ValueError("Grid image cannot have more than 256 rows or columns, increase `tile_size`.")
+        self._items_count += tile_columns * tile_rows + 1
+        if self._items_count > 1000:  # default libheif security limit during reading is 1000 items per file
+            raise ValueError(MAX_ITEMS_ERROR)
+        grid_handle = self.ctx_write.create_grid(
+            size[0],
+            size[1],
+            tile_columns,
+            tile_rows,
+            kwargs.get("save_nclx_profile", options.SAVE_NCLX_PROFILE),
+            *_output_nclx_params(kwargs, kwargs.get("nclx_profile")),
+            kwargs.get("image_orientation", 1),
+        )
+        self._add_grid_tiles(grid_handle, size, mode, data, tile_size=tile_size, **kwargs)
+        pixel_aspect_ratio = kwargs.get("pixel_aspect_ratio")
+        if pixel_aspect_ratio:
+            grid_handle.set_pixel_aspect_ratio(pixel_aspect_ratio[0], pixel_aspect_ratio[1])
+        if kwargs.get("primary"):
+            grid_handle.set_primary(self.ctx_write)
+        self._add_metadata(grid_handle, **kwargs)
+        thumbnails = [i for i in kwargs.get("thumbnails", []) if max(size) > i > 3]
+        if thumbnails:
+            pixels_im = self.ctx_write.create_image(size, MODE_INFO[mode][2], MODE_INFO[mode][3], 0)
+            _add_planes(pixels_im, size, mode, data, kwargs.get("stride", 0), _output_bit_depth(mode, **kwargs))
+            image_orientation = kwargs.get("image_orientation", 1)
+            self._items_count += len(thumbnails)
+            for thumb_box in thumbnails:
+                grid_handle.encode_thumbnail(self.ctx_write, thumb_box, image_orientation, pixels_im)
+        self._grid_images.append(grid_handle)
+
+    def _add_grid_tiles(self, grid_handle, size: tuple[int, int], mode: str, data, **kwargs) -> None:
+        tile_size = kwargs["tile_size"]
+        bit_depth_out = _output_bit_depth(mode, **kwargs)
+        bytes_per_pixel = MODE_INFO[mode][0] * (2 if MODE_INFO[mode][1] > 8 else 1)
+        src_stride = kwargs.get("stride", 0) or (size[0] * bytes_per_pixel)
+        if len(data) < src_stride * (size[1] - 1) + size[0] * bytes_per_pixel:
+            raise ValueError("Image plane does not contain enough data.")
+        icc_profile = kwargs.get("icc_profile")
+        tile_wh = (tile_size, tile_size)
+        for row in range(ceil(size[1] / tile_size)):
+            for col in range(ceil(size[0] / tile_size)):
+                tile_box = (
+                    col * tile_size,
+                    row * tile_size,
+                    min(tile_size, size[0] - col * tile_size),
+                    min(tile_size, size[1] - row * tile_size),
+                )
+                tile_data = _extract_tile(data, src_stride, bytes_per_pixel, tile_box, tile_size)
+                tile_im = self.ctx_write.create_image(
+                    tile_wh, MODE_INFO[mode][2], MODE_INFO[mode][3], int(mode.split(sep=";")[0][-1] == "a")
+                )
+                _add_planes(tile_im, tile_wh, mode, tile_data, 0, bit_depth_out)
+                if icc_profile is not None:
+                    tile_im.set_icc_profile(kwargs.get("icc_profile_type", "prof"), icc_profile)
+                self.ctx_write.add_tile(grid_handle, col, row, tile_im)
 
     def add_image_ycbcr(self, img: Image.Image, **kwargs) -> None:
         """Adds image in `YCbCR` mode to the encoder."""
+        tile_size = kwargs.pop("tile_size", None)
+        if tile_size is None:
+            tile_size = options.GRID_TILE_SIZE
+        if tile_size > 0 and (img.size[0] > tile_size or img.size[1] > tile_size):
+            raise ValueError("Grid encoding is not supported for `YCbCr` mode images, set `tile_size=0`.")
         # creating image
         im_out = self.ctx_write.create_image(img.size, MODE_INFO[img.mode][2], MODE_INFO[img.mode][3], 0)
         # image data
         for i in (HeifChannel.CHANNEL_Y, HeifChannel.CHANNEL_CB, HeifChannel.CHANNEL_CR):
             im_out.add_plane_l(img.size, 8, 8, bytes(img.getdata(i)), kwargs.get("stride", 0), i)
-        self._finish_add_image(im_out, img.size, **kwargs)
+        self._finish_add_image(im_out, img.size, img.mode, **kwargs)
 
-    def _finish_add_image(self, im_out, size: tuple[int, int], **kwargs):
+    def _finish_add_image(self, im_out, size: tuple[int, int], mode: str, **kwargs):
+        self._items_count += _items_per_image(mode)
         # set ICC color profile
         icc_profile = kwargs.get("icc_profile")
         if icc_profile is not None:
@@ -419,57 +580,42 @@ class CtxEncode:
             im_out.set_pixel_aspect_ratio(pixel_aspect_ratio[0], pixel_aspect_ratio[1])
         # encode
         image_orientation = kwargs.get("image_orientation", 1)
-        save_nclx = kwargs.get("save_nclx_profile", options.SAVE_NCLX_PROFILE)
-        nclx_keys = ("color_primaries", "transfer_characteristics", "matrix_coefficients", "full_range_flag")
-        has_explicit_nclx = any(k in kwargs for k in nclx_keys)
-        # When NCLX saving is enabled and no existing NCLX profile is on the image and no explicit NCLX parameters
-        # were provided, write an NCLX box that matches libheif internal sRGB encoding defaults.
-        # Without this, no NCLX box is written and viewers must guess the color space, which causes color shifts.
-        # See issue #365.
-        # Values match libheif nclx_profile::set_sRGB_defaults() exactly:
-        #   primaries=1 (BT.709)
-        #   transfer=13 (sRGB)
-        #   matrix=6 (BT.601)
-        #   full_range=1
-        if save_nclx and not kwargs.get("nclx_profile") and not has_explicit_nclx:
-            color_primaries = 1  # BT.709
-            transfer_characteristics = 13  # sRGB (IEC 61966-2-1)
-            matrix_coefficients = 6  # BT.601-6
-            full_range_flag = 1
-        else:
-            color_primaries = kwargs.get("color_primaries", -1)
-            transfer_characteristics = kwargs.get("transfer_characteristics", -1)
-            matrix_coefficients = kwargs.get("matrix_coefficients", -1)
-            full_range_flag = kwargs.get("full_range_flag", -1)
         im_out.encode(
             self.ctx_write,
             kwargs.get("primary", False),
-            save_nclx,
-            color_primaries,
-            transfer_characteristics,
-            matrix_coefficients,
-            full_range_flag,
+            kwargs.get("save_nclx_profile", options.SAVE_NCLX_PROFILE),
+            *_output_nclx_params(kwargs),
             image_orientation,
         )
         # adding metadata
+        self._add_metadata(im_out, **kwargs)
+        # adding thumbnails
+        for thumb_box in kwargs.get("thumbnails", []):
+            if max(size) > thumb_box > 3:
+                self._items_count += _items_per_image(mode)
+                im_out.encode_thumbnail(self.ctx_write, thumb_box, image_orientation)
+
+    def _add_metadata(self, im_out, **kwargs) -> None:
         exif = kwargs.get("exif")
         if exif is not None:
             if isinstance(exif, Image.Exif):
                 exif = exif.tobytes()
             im_out.set_exif(self.ctx_write, exif)
+            self._items_count += 1
         xmp = kwargs.get("xmp")
         if xmp is not None:
             im_out.set_xmp(self.ctx_write, xmp)
+            self._items_count += 1
         for metadata in kwargs.get("metadata", []):
             im_out.set_metadata(self.ctx_write, metadata["type"], metadata["content_type"], metadata["data"])
-        # adding thumbnails
-        for thumb_box in kwargs.get("thumbnails", []):
-            if max(size) > thumb_box > 3:
-                im_out.encode_thumbnail(self.ctx_write, thumb_box, image_orientation)
+            self._items_count += 1
 
     def save(self, fp) -> None:
         """Ask encoder to produce output based on previously added images."""
+        if self._grid_images and self._items_count > 1000:  # metadata of frames added after a grid
+            raise ValueError(MAX_ITEMS_ERROR)
         data = self.ctx_write.finalize()
+        self._grid_images.clear()
         if isinstance(fp, (str, Path)):
             Path(fp).write_bytes(data)
         elif hasattr(fp, "write"):
@@ -498,6 +644,7 @@ class MimCImage:
         self.pixel_aspect_ratio = None
         self.camera_intrinsic_matrix = None
         self.camera_extrinsic_matrix_rot = None
+        self.tiling = None
 
     @property
     def size_mode(self):

--- a/pillow_heif/options.py
+++ b/pillow_heif/options.py
@@ -81,3 +81,30 @@ DISABLE_SECURITY_LIMITS = False
 """Option to completely disable libheif security limits.
 
 Reference: https://github.com/strukturag/libheif/issues/1275"""
+
+
+GRID_TILE_SIZE = 0
+"""Default tile size for grid encoding.
+
+When set to a positive value, images larger than this size in at least one dimension
+will be split into a grid of tiles during encoding. This matches how Apple
+devices encode HEIF photos and can improve compression efficiency.
+
+Common values: 512 (Apple default), 256, 1024.
+A value of 0 (default) disables grid encoding.
+A grid cannot have more than 256 rows or columns and a file cannot have more than 1000 items
+in total: tiles, thumbnails and metadata blocks all count. Readers with default libheif
+security limits cannot open files with more items.
+
+Images with an alpha channel are always encoded as a single image: libheif stores alpha
+only on the individual tiles, where readers like Apple's ImageIO ignore it and render the
+image fully opaque. ``AVIF`` images are also encoded as a single image when the grid would
+violate MIAF constraints that ``libavif``-based readers enforce: a tile size smaller than 64,
+or an odd width, height or tile size together with subsampled chroma. Saving an image in
+``YCbCr`` mode with grid encoding enabled raises ``ValueError``.
+
+When use pillow_heif as a plugin you can set it with: `register_*_opener(grid_tile_size=512)`
+
+.. note:: For images that were read from a tiled HEIF file, the source tile size is used
+    by default during saving, except for images converted to ``YCbCr`` mode.
+    ``tile_size`` specified during calling ``save`` has higher priority."""

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -18,7 +18,7 @@ def test_libheif_info():
         assert key in info
 
     version = pillow_heif.libheif_version()
-    valid_prefixes = ["1.19.", "1.20.", "1.21", "1.22", "1.23"]
+    valid_prefixes = ["1.23"]
     assert any(version.startswith(prefix) for prefix in valid_prefixes)
 
 

--- a/tests/options_test.py
+++ b/tests/options_test.py
@@ -34,6 +34,7 @@ def test_options_change_from_plugin_registering(register_opener):
             save_nclx_profile=False,
             preferred_encoder={"HEIF": "id1", "AVIF": ""},
             preferred_decoder={"HEIF": "id3", "AVIF": ""},
+            grid_tile_size=512,
         )
         assert not options.THUMBNAILS
         assert options.QUALITY == 69
@@ -44,6 +45,7 @@ def test_options_change_from_plugin_registering(register_opener):
         assert options.SAVE_NCLX_PROFILE is False
         assert options.PREFERRED_ENCODER == {"HEIF": "id1", "AVIF": ""}
         assert options.PREFERRED_DECODER == {"HEIF": "id3", "AVIF": ""}
+        assert options.GRID_TILE_SIZE == 512
     finally:
         options.THUMBNAILS = True
         options.QUALITY = None
@@ -54,6 +56,7 @@ def test_options_change_from_plugin_registering(register_opener):
         options.SAVE_NCLX_PROFILE = True
         options.PREFERRED_ENCODER = {"HEIF": "", "AVIF": ""}
         options.PREFERRED_DECODER = {"HEIF": "", "AVIF": ""}
+        options.GRID_TILE_SIZE = 0
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="No HEVC encoder.")

--- a/tests/orientation_test.py
+++ b/tests/orientation_test.py
@@ -63,6 +63,31 @@ def test_exif_orientation(orientation, im_format):
             assert_image_similar(im, im_heif)
 
 
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+@pytest.mark.parametrize("orientation", (1, 2, 3, 4, 5, 6, 7, 8))
+def test_grid_exif_orientation(orientation):
+    out_im = BytesIO()
+    out_heif_im = BytesIO()
+    im = Image.effect_mandelbrot((256, 128), (-3, -2.5, 2, 2.5), 100).crop((0, 0, 256, 96))
+    im = im.convert(mode="RGB")
+    exif_data = Image.Exif()
+    exif_data[0x0112] = orientation
+    im.save(out_im, format="JPEG", exif=exif_data.tobytes())
+    im = Image.open(out_im)
+    im.save(out_heif_im, format="HEIF", quality=-1, tile_size=64)
+    out_heif_im.seek(0)
+    assert pillow_heif.open_heif(out_heif_im).info.get("tiling")
+    out_heif_im.seek(0)
+    im_heif = Image.open(out_heif_im)
+    im_heif_exif = im_heif.getexif()
+    assert 0x0112 not in im_heif_exif or im_heif_exif[0x0112] == 1
+    transposed_im = ImageOps.exif_transpose(im)
+    assert_image_similar(transposed_im, im_heif)
+    if orientation > 1:
+        with pytest.raises(AssertionError):
+            assert_image_similar(im, im_heif)
+
+
 @pytest.mark.parametrize("orientation", (1, 2, 3, 4, 5, 6, 7, 8))
 def test_png_xmp_orientation(orientation):
     im = Image.effect_mandelbrot((256, 128), (-3, -2.5, 2, 2.5), 100).crop((0, 0, 256, 96))

--- a/tests/read_test.py
+++ b/tests/read_test.py
@@ -445,6 +445,28 @@ def test_aux_image_ycbcr():
     assert aux_pil.mode == "RGB"
 
 
+@pytest.mark.parametrize(
+    "img_path,tiling",
+    (
+        # arrow.heic has orientation 6, `tiling` should be in the display space, the same as `size`
+        ("images/heif_other/arrow.heic", {"num_columns": 6, "num_rows": 8, "image_width": 3024, "image_height": 4032}),
+        ("images/heif_other/pug.heic", {"num_columns": 8, "num_rows": 6, "image_width": 4032, "image_height": 3024}),
+        (
+            "images/heif_special/xiaomi.heic",
+            {"num_columns": 6, "num_rows": 4, "image_width": 2592, "image_height": 1944},
+        ),
+        ("images/heif/zPug_3.heic", None),
+    ),
+)
+def test_read_tiling_info(img_path, tiling):
+    im = pillow_heif.open_heif(img_path)
+    if tiling is None:
+        assert im.info.get("tiling") is None
+    else:
+        assert im.info["tiling"] == {**tiling, "tile_width": 512, "tile_height": 512}
+        assert (im.info["tiling"]["image_width"], im.info["tiling"]["image_height"]) == im.size
+
+
 def test_read_heif_metadata():
     im = pillow_heif.open_heif("images/heif_other/spatial_photo.heic")
     assert "heif" in im.info

--- a/tests/write_test.py
+++ b/tests/write_test.py
@@ -723,3 +723,555 @@ def test_invalid_encoder():
         im_rgb.save(buf, format="HEIF")
     finally:
         pillow_heif.options.PREFERRED_ENCODER["HEIF"] = ""
+
+
+def _get_tiling_info(buf):
+    buf.seek(0)
+    return pillow_heif.open_heif(buf).info.get("tiling")
+
+
+def test_grid_encoding_basic():
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64)
+
+    tiling = _get_tiling_info(buf)
+    assert tiling is not None
+    assert tiling["num_columns"] == 4
+    assert tiling["num_rows"] == 4
+    assert tiling["tile_width"] == 64
+    assert tiling["tile_height"] == 64
+    assert tiling["image_width"] == 256
+    assert tiling["image_height"] == 256
+
+    buf.seek(0)
+    im_out = Image.open(buf)
+    assert im_out.size == (256, 256)
+    assert im_out.mode == "RGB"
+    helpers.compare_hashes([im, im_out], hash_size=16)
+
+
+def test_grid_encoding_non_divisible():
+    im = helpers.gradient_rgb().resize((301, 201))  # bright colored edges, to detect wrong edge tiles padding
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=128)
+
+    tiling = _get_tiling_info(buf)
+    assert tiling is not None
+    assert tiling["num_columns"] == 3
+    assert tiling["num_rows"] == 2
+    assert tiling["tile_width"] == 128
+    assert tiling["tile_height"] == 128
+    assert tiling["image_width"] == 301
+    assert tiling["image_height"] == 201
+
+    buf.seek(0)
+    im_out = Image.open(buf)
+    assert im_out.size == (301, 201)
+    helpers.assert_image_similar(im, im_out, 3.0)
+
+    buf_single = BytesIO()
+    im.save(buf_single, format="HEIF")
+    im_single = Image.open(buf_single)
+    # the right and bottom edge tiles are partial, compare their edges with the single image encoding
+    right_columns = (im.size[0] - 2, 0, im.size[0], im.size[1])
+    helpers.assert_image_similar(im_single.crop(right_columns), im_out.crop(right_columns), 3.0)
+    bottom_rows = (0, im.size[1] - 2, im.size[0], im.size[1])
+    helpers.assert_image_similar(im_single.crop(bottom_rows), im_out.crop(bottom_rows), 3.0)
+
+
+def test_grid_encoding_rgba():
+    # images with alpha fall back to single-image encoding: Apple's ImageIO ignores per-tile alpha
+    im = helpers.gradient_rgba()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=128)
+
+    assert _get_tiling_info(buf) is None
+
+    buf.seek(0)
+    im_out = Image.open(buf)
+    assert im_out.size == (256, 256)
+    assert im_out.mode == "RGBA"
+    helpers.compare_hashes([im, im_out], hash_size=16)
+    helpers.assert_image_similar(im.getchannel("A").convert("L"), im_out.getchannel("A").convert("L"), 0.05)
+
+
+def test_grid_encoding_grayscale():
+    im = Image.linear_gradient("L")
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64)
+
+    tiling = _get_tiling_info(buf)
+    assert tiling is not None
+    assert tiling["num_columns"] == 4
+    assert tiling["num_rows"] == 4
+
+    buf.seek(0)
+    im_out = Image.open(buf)
+    assert im_out.size == (256, 256)
+    assert im_out.mode == "L"
+    helpers.compare_hashes([im, im_out], hash_size=16)
+
+
+def test_grid_encoding_la():
+    im = helpers.gradient_la()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=128)
+
+    assert _get_tiling_info(buf) is None
+
+    buf.seek(0)
+    im_out = Image.open(buf)
+    assert im_out.size == (256, 256)
+    helpers.compare_hashes([im.convert("RGBA"), im_out], hash_size=16)
+    helpers.assert_image_similar(im.getchannel("A").convert("L"), im_out.getchannel("A").convert("L"), 0.05)
+
+
+def test_grid_encoding_small_image_bypass():
+    im = Image.new("RGB", (50, 50), color=(255, 0, 0))
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=128)
+
+    assert _get_tiling_info(buf) is None
+
+    buf.seek(0)
+    im_out = Image.open(buf)
+    assert im_out.size == (50, 50)
+
+
+def test_grid_encoding_single_column():
+    im = helpers.gradient_rgb().resize((64, 300))  # only the height exceeds the tile size
+    buf = BytesIO()
+    im.save(buf, format="HEIF", quality=-1, chroma=444, tile_size=128)
+
+    tiling = _get_tiling_info(buf)
+    assert (tiling["num_columns"], tiling["num_rows"]) == (1, 3)
+    buf.seek(0)
+    helpers.assert_image_similar(im, Image.open(buf), 2.0)
+
+
+def test_grid_encoding_global_option():
+    try:
+        pillow_heif.options.GRID_TILE_SIZE = 64
+        im = helpers.gradient_rgb()
+        buf = BytesIO()
+        im.save(buf, format="HEIF")
+
+        tiling = _get_tiling_info(buf)
+        assert tiling is not None
+        assert tiling["num_columns"] == 4
+        assert tiling["num_rows"] == 4
+    finally:
+        pillow_heif.options.GRID_TILE_SIZE = 0
+
+
+def test_grid_encoding_preserves_exif():
+    from PIL.ExifTags import Base as ExifBase
+
+    im = helpers.gradient_rgb()
+    exif = Image.Exif()
+    exif[ExifBase.Make] = "TestCamera"
+    exif[ExifBase.Model] = "TestModel"
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64, exif=exif.tobytes())
+
+    assert _get_tiling_info(buf) is not None
+
+    buf.seek(0)
+    im_out = Image.open(buf)
+    exif_out = im_out.getexif()
+    assert exif_out.get(ExifBase.Make) == "TestCamera"
+    assert exif_out.get(ExifBase.Model) == "TestModel"
+
+
+def test_grid_encoding_preserves_xmp():
+    im = helpers.gradient_rgb()
+    xmp_data = b'<?xpacket begin="\xef\xbb\xbf"?><x:xmpmeta xmlns:x="adobe:ns:meta/"></x:xmpmeta><?xpacket end="w"?>'
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64, xmp=xmp_data)
+
+    assert _get_tiling_info(buf) is not None
+
+    buf.seek(0)
+    im_out = Image.open(buf)
+    assert im_out.info.get("xmp") is not None
+    assert b"xmpmeta" in im_out.info["xmp"]
+
+
+def test_grid_encoding_preserves_icc():
+    from PIL import ImageCms
+
+    icc = ImageCms.ImageCmsProfile(ImageCms.createProfile("sRGB")).tobytes()
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64, icc_profile=icc)
+
+    assert _get_tiling_info(buf) is not None
+    buf.seek(0)
+    assert pillow_heif.open_heif(buf).info["icc_profile"] == icc
+
+
+def test_grid_encoding_standalone_api():
+    im = Image.new("RGB", (256, 256), color=(100, 200, 50))
+    heif_im = pillow_heif.from_pillow(im)
+    buf = BytesIO()
+    heif_im.save(buf, tile_size=64)
+
+    tiling = _get_tiling_info(buf)
+    assert tiling is not None
+    assert tiling["num_columns"] == 4
+    assert tiling["num_rows"] == 4
+
+    buf.seek(0)
+    heif_out = pillow_heif.open_heif(buf)
+    assert heif_out.size == (256, 256)
+
+
+def test_grid_encoding_multi_image():
+    im1 = Image.new("RGB", (256, 256), color=(255, 0, 0))
+    im2 = Image.new("RGB", (128, 128), color=(0, 255, 0))
+    buf = BytesIO()
+    im1.save(buf, format="HEIF", save_all=True, append_images=[im2], tile_size=64)
+
+    buf.seek(0)
+    im_out = Image.open(buf)
+    assert im_out.n_frames == 2
+    assert im_out.size == (256, 256)
+    assert im_out.info["tiling"]["num_columns"] == 4
+    im_out.seek(1)
+    im_out.load()
+    assert im_out.size == (128, 128)
+    assert im_out.info["tiling"]["num_columns"] == 2
+
+    buf = BytesIO()
+    im1.save(buf, format="HEIF", save_all=True, append_images=[im2], tile_size=64, primary_index=1)
+    buf.seek(0)
+    assert pillow_heif.open_heif(buf).primary_index == 1
+
+
+def test_grid_encoding_vs_single_roundtrip():
+    im = helpers.gradient_rgb()
+
+    buf_single = BytesIO()
+    im.save(buf_single, format="HEIF", quality=90)
+    buf_single.seek(0)
+
+    buf_grid = BytesIO()
+    im.save(buf_grid, format="HEIF", quality=90, tile_size=64)
+    buf_grid.seek(0)
+
+    im_single = Image.open(buf_single)
+    im_grid = Image.open(buf_grid)
+
+    assert im_single.size == im_grid.size
+    assert im_single.mode == im_grid.mode
+    helpers.compare_hashes([im_single, im_grid], hash_size=16)
+
+
+def test_grid_no_tiling_info_for_single_image():
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF")
+
+    assert _get_tiling_info(buf) is None
+
+
+def test_grid_encoding_nclx_profile():
+    srgb_nclx = {
+        "color_primaries": 1,
+        "transfer_characteristics": 13,
+        "matrix_coefficients": 6,
+        "full_range_flag": 1,
+    }
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", quality=90, tile_size=64)
+    assert _get_tiling_info(buf) is not None
+    nclx_grid = Image.open(buf).info.get("nclx_profile")
+    assert nclx_grid is not None
+    for k in srgb_nclx:
+        assert srgb_nclx[k] == nclx_grid[k]
+
+
+def test_grid_encoding_nclx_disabled():
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64, save_nclx_profile=False)
+    assert _get_tiling_info(buf) is not None
+    assert "nclx_profile" not in Image.open(buf).info
+
+
+def test_grid_encoding_pixel_aspect_ratio():
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64, pixel_aspect_ratio=(4, 3))
+
+    assert _get_tiling_info(buf) is not None
+
+    buf.seek(0)
+    heif_out = pillow_heif.open_heif(buf)
+    assert heif_out.info.get("pixel_aspect_ratio") == (4, 3)
+
+
+def test_grid_encoding_orientation():
+    im = Image.effect_mandelbrot((256, 128), (-3, -2.5, 2, 2.5), 100).crop((0, 0, 256, 96))
+    im = im.convert(mode="RGB")
+    exif_data = Image.Exif()
+    exif_data[0x0112] = 6  # 90 CW rotation
+
+    buf_single = BytesIO()
+    im.save(buf_single, format="HEIF", quality=-1, exif=exif_data.tobytes())
+    im_single = Image.open(buf_single)
+
+    buf_grid = BytesIO()
+    im.save(buf_grid, format="HEIF", quality=-1, tile_size=64, exif=exif_data.tobytes())
+    im_grid = Image.open(buf_grid)
+
+    assert im_grid.info.get("original_orientation") == 6
+    helpers.assert_image_similar(im_single, im_grid)
+
+
+@pytest.mark.parametrize(
+    "im_path,expected_bit_depth,expected_grid",
+    (
+        ("images/heif/RGB_10__128x128.heif", 10, True),
+        ("images/heif/RGB_12__128x128.heif", 12, True),
+        ("images/heif/RGBA_12__128x128.heif", 12, False),
+    ),
+)
+def test_grid_encoding_hdr(im_path, expected_bit_depth, expected_grid):
+    heif_file = pillow_heif.open_heif(im_path, convert_hdr_to_8bit=False)
+    buf = BytesIO()
+    heif_file.save(buf, quality=-1, chroma=444, tile_size=64)
+    buf_single = BytesIO()
+    heif_file.save(buf_single, quality=-1, chroma=444, tile_size=0)
+
+    heif_file_out = pillow_heif.open_heif(buf, convert_hdr_to_8bit=False)
+    if expected_grid:
+        assert heif_file_out.info["tiling"]["num_columns"] == 2
+    else:  # images with alpha fall back to single-image encoding
+        assert "tiling" not in heif_file_out.info
+    assert heif_file_out.info["bit_depth"] == expected_bit_depth
+    helpers.compare_hashes([buf, buf_single], hash_size=16)
+
+
+@pytest.mark.parametrize("save_to_12bit,expected_bit_depth", ((False, 10), (True, 12)))
+def test_grid_encoding_16bit_input(save_to_12bit, expected_bit_depth):
+    im = Image.effect_mandelbrot((128, 128), (-3, -2.5, 2, 2.5), 100).convert(mode="I;16")
+    heif_file = pillow_heif.from_pillow(im)
+    try:
+        pillow_heif.options.SAVE_HDR_TO_12_BIT = save_to_12bit
+        buf = BytesIO()
+        heif_file.save(buf, quality=-1, chroma=444, tile_size=64)
+        buf_single = BytesIO()
+        heif_file.save(buf_single, quality=-1, chroma=444, tile_size=0)
+    finally:
+        pillow_heif.options.SAVE_HDR_TO_12_BIT = False
+
+    heif_file_out = pillow_heif.open_heif(buf, convert_hdr_to_8bit=False)
+    assert heif_file_out.info["tiling"]["num_columns"] == 2
+    assert heif_file_out.info["bit_depth"] == expected_bit_depth
+    helpers.compare_hashes([buf, buf_single], hash_size=16)
+
+
+def test_grid_encoding_stride():
+    im = Image.effect_mandelbrot((512, 256), (-3, -2.5, 2, 2.5), 100).convert(mode="RGB")
+    buf = BytesIO()
+    pillow_heif.encode(im.mode, (257, im.size[1]), im.tobytes(), buf, quality=-1, stride=512 * 3, tile_size=128)
+    assert _get_tiling_info(buf) is not None
+    im = im.crop((0, 0, 257, 256))
+    helpers.compare_hashes([buf, im], hash_size=32)
+
+
+def test_grid_encoding_nclx_resave():
+    nclx_profile = {
+        "color_primaries": 9,
+        "transfer_characteristics": 16,
+        "matrix_coefficients": 9,
+        "full_range_flag": 0,
+    }
+    im = helpers.gradient_rgb()
+    im.info["nclx_profile"] = nclx_profile
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64)  # the existing profile values should be written to the grid
+
+    nclx_out = Image.open(buf).info["nclx_profile"]
+    for key, value in nclx_profile.items():
+        assert nclx_out[key] == value
+
+
+def test_grid_encoding_nclx_explicit():
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64, matrix_coefficients=0, full_range_flag=1)
+
+    nclx_out = Image.open(buf).info["nclx_profile"]
+    assert nclx_out["matrix_coefficients"] == 0
+    assert nclx_out["full_range_flag"] == 1
+
+
+def test_grid_encoding_resave():
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64)
+
+    buf_resave = BytesIO()
+    Image.open(buf).save(buf_resave, format="HEIF")  # the grid structure is preserved by default
+    tiling = _get_tiling_info(buf_resave)
+    assert tiling is not None
+    assert tiling["tile_width"] == 64
+
+    buf_resave = BytesIO()
+    Image.open(buf).save(buf_resave, format="HEIF", tile_size=128)  # explicit `tile_size` has higher priority
+    tiling = _get_tiling_info(buf_resave)
+    assert tiling is not None
+    assert tiling["tile_width"] == 128
+
+    buf_resave = BytesIO()
+    Image.open(buf).save(buf_resave, format="HEIF", tile_size=0)  # zero disables the grid
+    assert _get_tiling_info(buf_resave) is None
+
+    try:
+        pillow_heif.options.GRID_TILE_SIZE = 512
+        buf_resave = BytesIO()
+        Image.open(buf).save(buf_resave, format="HEIF")  # the source tile size has priority over the global option
+        assert _get_tiling_info(buf_resave)["tile_width"] == 64
+    finally:
+        pillow_heif.options.GRID_TILE_SIZE = 0
+
+
+def test_grid_encoding_multi_image_standalone():
+    heif_file = pillow_heif.HeifFile()
+    heif_file.add_from_pillow(helpers.gradient_rgb())
+    heif_file.add_from_pillow(helpers.gradient_rgba().convert("RGB"))
+    buf = BytesIO()
+    heif_file.save(buf, tile_size=64)
+
+    heif_out = pillow_heif.open_heif(buf)
+    assert len(heif_out) == 2
+    for im in heif_out:
+        assert im.info["tiling"]["tile_width"] == 64
+
+
+def test_grid_encoding_thumbnails():
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64, thumbnails=[128])
+
+    assert _get_tiling_info(buf) is not None
+    buf.seek(0)
+    heif_file = pillow_heif.open_heif(buf)
+    assert heif_file.info["thumbnails"] == [128]
+    im_out = Image.open(buf)
+    helpers.compare_hashes([im, im_out], hash_size=16)
+
+
+def test_grid_encoding_too_many_tiles():
+    im = Image.new("RGB", (257 * 64, 64))
+    with pytest.raises(ValueError, match="more than 256 rows or columns"):
+        im.save(BytesIO(), format="HEIF", tile_size=64)
+    im = Image.new("RGB", (40 * 64, 25 * 64))  # 1000 tiles + grid item, default libheif reader limit is 1000 items
+    with pytest.raises(ValueError, match="more than 1000 items"):
+        im.save(BytesIO(), format="HEIF", tile_size=64)
+    im = Image.new("RGB", (25 * 64, 20 * 64))  # 500 tiles per frame, the items limit is for the whole file
+    with pytest.raises(ValueError, match="more than 1000 items"):
+        im.save(BytesIO(), format="HEIF", save_all=True, append_images=[im], tile_size=64)
+
+
+def test_grid_encoding_items_limit_boundary():
+    im = helpers.gradient_rgb().resize((128, 128))
+    heif_file = pillow_heif.from_pillow(im)
+    # 4 tiles + grid item + 995 metadata blocks = 1000 items, the file is readable
+    heif_file[0].info["metadata"] = [{"type": "cust", "content_type": "", "data": b"1"}] * 995
+    buf = BytesIO()
+    heif_file.save(buf, tile_size=64)
+    out = pillow_heif.open_heif(buf)
+    assert out.info["tiling"]["num_columns"] == 2
+    assert len(out.info["metadata"]) == 995
+    # 1001 items would not be readable, `save` should raise an error before writing anything
+    heif_file[0].info["metadata"] = [{"type": "cust", "content_type": "", "data": b"1"}] * 996
+    buf = BytesIO()
+    with pytest.raises(ValueError, match="more than 1000 items"):
+        heif_file.save(buf, tile_size=64)
+    assert buf.getbuffer().nbytes == 0
+
+
+def test_grid_encoding_not_enough_data():
+    im = helpers.gradient_rgb().resize((301, 201))
+    data = im.tobytes()
+    with pytest.raises(ValueError):
+        pillow_heif.encode(im.mode, im.size, data[:-5000], BytesIO(), tile_size=128)
+
+
+def test_grid_encoding_from_pillow_resave():
+    im = helpers.gradient_rgb()
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=64)
+
+    buf_resave = BytesIO()
+    pillow_heif.from_pillow(Image.open(buf)).save(buf_resave)
+    tiling = _get_tiling_info(buf_resave)
+    assert tiling is not None
+    assert tiling["tile_width"] == 64
+
+
+def test_grid_encoding_premultiplied_alpha():
+    heif_file = pillow_heif.from_pillow(helpers.gradient_rgba())
+    heif_file.premultiplied_alpha = True
+    buf = BytesIO()
+    heif_file.save(buf, quality=-1, tile_size=64)
+    out_heif_file = pillow_heif.open_heif(buf)
+    assert out_heif_file.info.get("tiling") is None
+    assert out_heif_file.premultiplied_alpha
+
+
+def test_grid_encoding_ycbcr():
+    im = Image.new("YCbCr", (256, 128), color=(128, 128, 128))
+    with pytest.raises(ValueError):
+        im.save(BytesIO(), format="HEIF", tile_size=64)
+    with pytest.raises(ValueError):  # the standalone API path raises too
+        pillow_heif.encode("YCbCr", (256, 128), bytes(256 * 128 * 3), BytesIO(), tile_size=64)
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=512)
+    assert _get_tiling_info(buf) is None
+    buf = BytesIO()
+    im.save(buf, format="HEIF", tile_size=None)
+    assert _get_tiling_info(buf) is None
+
+    buf_rgb = BytesIO()
+    helpers.gradient_rgb().save(buf_rgb, format="HEIF", tile_size=64)
+    im = Image.open(buf_rgb).convert("YCbCr")  # the source info["tiling"] must be ignored for `YCbCr`
+    buf = BytesIO()
+    im.save(buf, format="HEIF")
+    assert _get_tiling_info(buf) is None
+
+
+@pytest.mark.skipif(not pillow_heif.libheif_info()["AVIF"], reason="Requires AVIF encoder.")
+@pytest.mark.parametrize(
+    "mode,size,params,expected_grid",
+    (
+        ("RGB", (256, 256), {}, True),
+        ("RGB", (301, 201), {}, False),  # odd dimensions with subsampled chroma violate MIAF parity rules
+        ("RGB", (301, 201), {"chroma": 444}, True),
+        ("RGB", (256, 256), {"tile_size": 32}, False),  # MIAF requires tile sizes of at least 64
+        ("L", (301, 201), {}, True),  # monochrome images have no chroma parity constraints
+    ),
+)
+def test_grid_encoding_avif(mode, size, params, expected_grid):
+    from PIL import AvifImagePlugin, features
+
+    im = helpers.gradient_rgb().resize(size)
+    if mode == "L":
+        im = im.convert("L")
+    buf = BytesIO()
+    pillow_heif.from_pillow(im).save(buf, format="AVIF", quality=90, **{"tile_size": 128, **params})
+    assert (_get_tiling_info(buf) is not None) == expected_grid
+    avif_version = features.version("avif") if features.check("avif") else None
+    # libavif-based readers (Pillow, Chrome) must accept every produced file;
+    # libavif < 1.1 cannot parse the `iloc` layout libheif writes for multi-item files at all
+    if avif_version and tuple(map(int, avif_version.split(".")[:2])) >= (1, 1):
+        buf.seek(0)
+        im_out = AvifImagePlugin.AvifImageFile(buf)
+        im_out.load()
+        assert im_out.size == size
+        helpers.assert_image_similar(im.convert("RGB"), im_out.convert("RGB"), 5.0)


### PR DESCRIPTION
Closes #317

1. Grid(tiled) image encoding: `options.GRID_TILE_SIZE` (0 = off, e.g. 512 for Apple-style tiles), `tile_size=` save kwarg and `grid_tile_size=` for `register_*_opener`; decode exposes `info["tiling"]`
2. Orientation is written natively to the grid item, requires the upstream fix shipped in libheif `1.22` - minimum required `libheif` version raised to `1.23.0`
3. Encoding releases the GIL while adding tiles; grid decode is multithreaded by libheif natively (~30-40% faster reads of tiled files)
4. `test.yml` jobs now build libheif `1.23.0` from source instead of the PPA (it ships `1.19.8`); the plugin-load test uses the aom decoder plugin built by `build_libs.py` (`PH_LIBHEIF_PLUGINS=1`)