### PR TITLE
ci: take freshly built libheif plugin for the load test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,9 @@ jobs:
 
       - name: Prepare libheif plugin for load test
         run: |
-          PLUGIN_SO=$(find /usr/lib -name "libheif-aomdec.so" -print -quit)
+          # "-path" filter: the runner image also ships Ubuntu`s stale libheif plugins in "libheif/plugins/"
+          PLUGIN_SO=$(find /usr/lib -path "*/libheif/libheif-aomdec.so" -print -quit)
+          echo "Using plugin: $PLUGIN_SO"
           sudo mv "$PLUGIN_SO" "$GITHUB_WORKSPACE/"
           echo "TEST_PLUGIN_LOAD=$GITHUB_WORKSPACE/libheif-aomdec.so" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Updated runner image ships Ubuntu's stale libheif plugins in `libheif/plugins/`; `find /usr/lib` picked the system `libheif-aomdec.so` (plugin API v3) instead of the freshly built one, failing `test_load_plugin` with "Decoder plugin needs to be at least version 6".