### PR TITLE
fix: use-after-free when image data outlives the HeifFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.6.0 - ]
 
+### Fixed
+
+- Use-after-free when a numpy array or the `data` memoryview outlived the `HeifFile` it was created from. #453
+
 ## [1.5.0 - 2026-07-22]
 
 ### Added

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -1429,16 +1429,23 @@ static PyObject* _CtxImage_stride(CtxImageObject* self, void* closure) {
     return PyLong_FromSsize_t(self->stride);
 }
 
-static PyObject* _CtxImage_data(CtxImageObject* self, void* closure) {
+static int _CtxImage_getbuffer(CtxImageObject* self, Py_buffer* view, int flags) {
     MUTEX_LOCK(&self->decode_mutex);
     if (!self->data) {
         if (!decode_image(self)) {
             MUTEX_UNLOCK(&self->decode_mutex);
-            return NULL;
+            view->obj = NULL;
+            return -1;
         }
     }
     MUTEX_UNLOCK(&self->decode_mutex);
-    return PyMemoryView_FromMemory((char*)self->data, self->stride * self->height, PyBUF_READ);
+    return PyBuffer_FillInfo(view, (PyObject*)self, self->data, (Py_ssize_t)self->stride * self->height, 1, flags);
+}
+
+static PyObject* _CtxImage_data(CtxImageObject* self, void* closure) {
+    // a view of the object, not of raw memory: it keeps the CtxImage alive,
+    // so the underlying heif_image plane cannot be released while views exist
+    return PyMemoryView_FromObject((PyObject*)self);
 }
 
 static PyObject* _CtxImage_depth_image_list(CtxImageObject* self, void* closure) {
@@ -1861,6 +1868,10 @@ static PyTypeObject CtxWrite_Type = {
     .tp_methods = _CtxWrite_methods,
 };
 
+static PyBufferProcs _CtxImage_as_buffer = {
+    .bf_getbuffer = (getbufferproc)_CtxImage_getbuffer,
+};
+
 static PyTypeObject CtxImage_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "CtxImage",
@@ -1868,6 +1879,7 @@ static PyTypeObject CtxImage_Type = {
     .tp_itemsize = 0,
     .tp_dealloc = (destructor)_CtxImage_destructor,
     .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_as_buffer = &_CtxImage_as_buffer,
     .tp_getset = _CtxImage_getseters,
     .tp_methods = _CtxImage_methods,
 };

--- a/tests/modes_test.py
+++ b/tests/modes_test.py
@@ -1,3 +1,4 @@
+import gc
 import os
 from io import BytesIO
 
@@ -143,3 +144,18 @@ def test_open_save_disable_16bit(img, remove_stride):
     im.save(buf)
     im_out = open_heif(buf, convert_hdr_to_8bit=False, hdr_to_16bit=False, remove_stride=remove_stride)
     compare_heif_files_fields(im, im_out)
+
+
+def test_numpy_array_outlives_heif_file():
+    heif_file = open_heif("images/heif/RGB_8__128x128.heif")
+    arr = np.asarray(heif_file)
+    expected = arr.copy()
+    base = arr.base
+    while isinstance(base, np.ndarray):
+        base = base.base
+    assert base.obj is not None  # the view must own the decoded image, not just point into it
+    del heif_file
+    gc.collect()
+    reuse_pressure = [bytes(arr.nbytes) for _ in range(4)]
+    assert np.array_equal(arr, expected)
+    assert reuse_pressure


### PR DESCRIPTION
1. `np.asarray(open_heif(path))` returned an array viewing memory freed together with the `HeifFile` (the pattern from the README example); same for any `data` memoryview kept after the image object died
2. `CtxImage` now implements the buffer protocol and `data` returns a view of the object, so views own a reference to the decoded image and the plane is released only after the last view is gone