### PR TITLE
fix: conflicting license metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Use-after-free when a numpy array or the `data` memoryview outlived the `HeifFile` it was created from. #453
+- Conflicting license metadata: removed the `GPLv2` classifier, the package license is `BSD-3-Clause`; bundled library licenses in wheels are described in `LICENSES_bundled.txt`, which was updated to match the current libraries. #455
 
 ## [1.5.0 - 2026-07-22]
 

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -1,3 +1,4 @@
+The "pillow-heif" source code is licensed under the BSD-3-Clause license, see LICENSE.txt.
 License for "pillow-heif" binary wheels: GPLv2, due to base library licenses.
 
 Binary wheels combine several license-compatible libraries. Here they are listed.
@@ -5,23 +6,22 @@ Binary wheels combine several license-compatible libraries. Here they are listed
 Name: libheif
 License: LGPLv3
 Files: libheif.[dylib|so|dll]
-  For details, see https://github.com/strukturag/libheif/tree/v1.18.1/COPYING
-  Source code: https://github.com/strukturag/libheif/tree/v1.18.1
+  For details, see https://github.com/strukturag/libheif/tree/v1.23.1/COPYING
+  Source code: https://github.com/strukturag/libheif/tree/v1.23.1
 
 Name: libde265
 License: LGPLv3
 Files: libde265.[dylib|so|dll]
-  For details, see https://github.com/strukturag/libde265/tree/v1.0.15/COPYING
-  Source code: https://github.com/strukturag/libde265/tree/v1.0.15
+  For details, see https://github.com/strukturag/libde265/tree/v1.1.1/COPYING
+  Source code: https://github.com/strukturag/libde265/tree/v1.1.1
 
 Name: x265
 License: GPLv2
 Files: libx265.[dylib|so|dll]
-  For details, see https://bitbucket.org/multicoreware/x265_git/src/Release_3.4/COPYING
-  Source code: https://bitbucket.org/multicoreware/x265_git/src/Release_3.4
+  For details, see https://bitbucket.org/multicoreware/x265_git/src/4.2/COPYING
+  Source code: https://bitbucket.org/multicoreware/x265_git/src/4.2
 
-Name: libaom
-License: BSD 3-Clause
-Files: libaom.[dylib|so|dll]
-  For details, see https://aomedia.googlesource.com/aom/+/refs/tags/v3.6.1/LICENSE
-  Source code: https://aomedia.googlesource.com/aom/+/refs/tags/v3.6.1
+Name: MinGW-w64 runtime (Windows wheels only)
+License: GPL-3.0-with-GCC-exception (libgcc, libstdc++), MIT and BSD (libwinpthread)
+Files: libgcc_s_seh-1.dll, libstdc++-6.dll, libwinpthread-1.dll
+  For details, see https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/COPYING

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
-    License :: OSI Approved :: GNU General Public License v2 (GPLv2)
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
     Operating System :: Microsoft :: Windows


### PR DESCRIPTION
1. removed the `GPLv2` classifier that conflicted with `license = BSD-3-Clause`; package metadata now declares only the source code license
2. updated `LICENSES_bundled.txt` to the libraries currently bundled in wheels: libheif 1.23.1, libde265 1.1.1, x265 4.2, MinGW-w64 runtime DLLs; removed libaom (AVIF support was dropped)

Fixes #441