### PR TITLE
feat: read and write HDR metadata (clli, mdcv, amve)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.6.0 - ]
 
+### Added
+
+- Reading and writing HDR metadata: `content_light_level`, `mastering_display_colour_volume`, `ambient_viewing_environment` keys in `info` dictionary. #456
+
 ### Fixed
 
 - Use-after-free when a numpy array or the `data` memoryview outlived the `HeifFile` it was created from. #453

--- a/docs/reference/HeifImage.rst
+++ b/docs/reference/HeifImage.rst
@@ -66,6 +66,39 @@ HeifImage object
             * `matrix_coefficients`: :py:class:`HeifMatrixCoefficients`
             * `full_range_flag`: `bool`
 
+    .. py:attribute:: info["content_light_level"]
+        :type: dict
+
+        Content light level information(``clli``). Can be absent. Keys:
+
+            * `max_content_light_level`: `int`
+            * `max_pic_average_light_level`: `int`
+
+    .. py:attribute:: info["mastering_display_colour_volume"]
+        :type: dict
+
+        Mastering display colour volume(``mdcv``). Can be absent. Keys:
+
+            * `display_primaries_x`: `tuple[int, int, int]`
+            * `display_primaries_y`: `tuple[int, int, int]`
+            * `white_point_x`: `int`
+            * `white_point_y`: `int`
+            * `max_display_mastering_luminance`: `int`
+            * `min_display_mastering_luminance`: `int`
+
+    .. py:attribute:: info["ambient_viewing_environment"]
+        :type: dict
+
+        Ambient viewing environment(``amve``). Can be absent. Keys:
+
+            * `ambient_illumination`: `int`
+            * `ambient_light_x`: `int`
+            * `ambient_light_y`: `int`
+
+        .. note:: These three properties hold the raw code values as defined in ITU-T H.274.
+            Like ``nclx_profile`` and ``icc_profile`` they are written back during save;
+            remove a key from ``info`` if you do not want it in the output file.
+
     .. py:attribute:: info["depth_images"]
         :type: list
 

--- a/docs/saving-images.rst
+++ b/docs/saving-images.rst
@@ -137,6 +137,21 @@ Here is additional info, from the **libheif repo** with relevant information:
 https://github.com/strukturag/libheif/discussions/931
 https://github.com/strukturag/libheif/issues/995
 
+HDR metadata
+""""""""""""
+
+``content_light_level``, ``mastering_display_colour_volume`` and ``ambient_viewing_environment``
+from ``image.info`` are written to the output file as is, the same as they can be specified as
+``save`` keyword arguments(applies to the primary image):
+
+    .. code-block:: python
+
+        im.save(buf, format="HEIF", content_light_level={"max_content_light_level": 1000, "max_pic_average_light_level": 400})
+
+    .. note:: They are passed through also when an HDR image was opened with ``convert_hdr_to_8bit=True``:
+        the decoded data keeps the original transfer characteristics, so the metadata stays valid.
+        Remove a key from ``info`` before saving if you do not want it in the output file.
+
 Lossless encoding
 """""""""""""""""
 

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -571,6 +571,43 @@ static PyObject* _CtxWriteImage_set_pixel_aspect_ratio(CtxWriteImageObject* self
     Py_RETURN_NONE;
 }
 
+static PyObject* _CtxWriteImage_set_content_light_level(CtxWriteImageObject* self, PyObject* args) {
+    struct heif_content_light_level clli;
+    if (!PyArg_ParseTuple(args, "HH", &clli.max_content_light_level, &clli.max_pic_average_light_level))
+        return NULL;
+    if (self->handle)
+        heif_image_handle_set_content_light_level(self->handle, &clli);
+    else
+        heif_image_set_content_light_level(self->image, &clli);
+    Py_RETURN_NONE;
+}
+
+static PyObject* _CtxWriteImage_set_mastering_display_colour_volume(CtxWriteImageObject* self, PyObject* args) {
+    struct heif_mastering_display_colour_volume mdcv;
+    if (!PyArg_ParseTuple(args, "(HHH)(HHH)HHII",
+        &mdcv.display_primaries_x[0], &mdcv.display_primaries_x[1], &mdcv.display_primaries_x[2],
+        &mdcv.display_primaries_y[0], &mdcv.display_primaries_y[1], &mdcv.display_primaries_y[2],
+        &mdcv.white_point_x, &mdcv.white_point_y,
+        &mdcv.max_display_mastering_luminance, &mdcv.min_display_mastering_luminance))
+        return NULL;
+    if (self->handle)
+        heif_image_handle_set_mastering_display_colour_volume(self->handle, &mdcv);
+    else
+        heif_image_set_mastering_display_colour_volume(self->image, &mdcv);
+    Py_RETURN_NONE;
+}
+
+static PyObject* _CtxWriteImage_set_ambient_viewing_environment(CtxWriteImageObject* self, PyObject* args) {
+    struct heif_ambient_viewing_environment amve;
+    if (!PyArg_ParseTuple(args, "IHH", &amve.ambient_illumination, &amve.ambient_light_x, &amve.ambient_light_y))
+        return NULL;
+    if (self->handle)
+        heif_image_handle_set_ambient_viewing_environment(self->handle, &amve);
+    else
+        heif_image_set_ambient_viewing_environment(self->image, &amve);
+    Py_RETURN_NONE;
+}
+
 static PyObject* _CtxWriteImage_encode(CtxWriteImageObject* self, PyObject* args) {
     /* ctx: CtxWriteObject, primary: int */
     CtxWriteObject* ctx_write;
@@ -731,6 +768,9 @@ static struct PyMethodDef _CtxWriteImage_methods[] = {
     {"set_icc_profile", (PyCFunction)_CtxWriteImage_set_icc_profile, METH_VARARGS},
     {"set_nclx_profile", (PyCFunction)_CtxWriteImage_set_nclx_profile, METH_VARARGS},
     {"set_pixel_aspect_ratio", (PyCFunction)_CtxWriteImage_set_pixel_aspect_ratio, METH_VARARGS},
+    {"set_content_light_level", (PyCFunction)_CtxWriteImage_set_content_light_level, METH_VARARGS},
+    {"set_mastering_display_colour_volume", (PyCFunction)_CtxWriteImage_set_mastering_display_colour_volume, METH_VARARGS},
+    {"set_ambient_viewing_environment", (PyCFunction)_CtxWriteImage_set_ambient_viewing_environment, METH_VARARGS},
     {"encode", (PyCFunction)_CtxWriteImage_encode, METH_VARARGS},
     {"set_exif", (PyCFunction)_CtxWriteImage_set_exif, METH_VARARGS},
     {"set_xmp", (PyCFunction)_CtxWriteImage_set_xmp, METH_VARARGS},
@@ -1539,6 +1579,38 @@ static PyObject* _CtxImage_pixel_aspect_ratio(CtxImageObject* self, void* closur
     Py_RETURN_NONE;
 }
 
+static PyObject* _CtxImage_content_light_level(CtxImageObject* self, void* closure) {
+    struct heif_content_light_level clli;
+    if (!heif_image_handle_get_content_light_level(self->handle, &clli))
+        Py_RETURN_NONE;
+    return Py_BuildValue("{sHsH}",
+        "max_content_light_level", clli.max_content_light_level,
+        "max_pic_average_light_level", clli.max_pic_average_light_level);
+}
+
+static PyObject* _CtxImage_mastering_display_colour_volume(CtxImageObject* self, void* closure) {
+    struct heif_mastering_display_colour_volume mdcv;
+    if (!heif_image_handle_get_mastering_display_colour_volume(self->handle, &mdcv))
+        Py_RETURN_NONE;
+    return Py_BuildValue("{s(HHH)s(HHH)sHsHsIsI}",
+        "display_primaries_x", mdcv.display_primaries_x[0], mdcv.display_primaries_x[1], mdcv.display_primaries_x[2],
+        "display_primaries_y", mdcv.display_primaries_y[0], mdcv.display_primaries_y[1], mdcv.display_primaries_y[2],
+        "white_point_x", mdcv.white_point_x,
+        "white_point_y", mdcv.white_point_y,
+        "max_display_mastering_luminance", mdcv.max_display_mastering_luminance,
+        "min_display_mastering_luminance", mdcv.min_display_mastering_luminance);
+}
+
+static PyObject* _CtxImage_ambient_viewing_environment(CtxImageObject* self, void* closure) {
+    struct heif_ambient_viewing_environment amve;
+    if (!heif_image_handle_get_ambient_viewing_environment(self->handle, &amve))
+        Py_RETURN_NONE;
+    return Py_BuildValue("{sIsHsH}",
+        "ambient_illumination", amve.ambient_illumination,
+        "ambient_light_x", amve.ambient_light_x,
+        "ambient_light_y", amve.ambient_light_y);
+}
+
 static PyObject* _CtxImage_tiling(CtxImageObject* self, void* closure) {
     struct heif_image_tiling tiling;
     /* process_image_transformations=1: report display space values, like all other dimensions we expose */
@@ -1612,6 +1684,9 @@ static struct PyGetSetDef _CtxImage_getseters[] = {
     {"depth_image_list", (getter)_CtxImage_depth_image_list, NULL, NULL, NULL},
     {"aux_image_ids", (getter)_CtxImage_aux_image_ids, NULL, NULL, NULL},
     {"pixel_aspect_ratio", (getter)_CtxImage_pixel_aspect_ratio, NULL, NULL, NULL},
+    {"content_light_level", (getter)_CtxImage_content_light_level, NULL, NULL, NULL},
+    {"mastering_display_colour_volume", (getter)_CtxImage_mastering_display_colour_volume, NULL, NULL, NULL},
+    {"ambient_viewing_environment", (getter)_CtxImage_ambient_viewing_environment, NULL, NULL, NULL},
     {"camera_intrinsic_matrix", (getter)_CtxImage_camera_intrinsic_matrix, NULL, NULL, NULL},
     {"camera_extrinsic_matrix_rot", (getter)_CtxImage_camera_extrinsic_matrix_rot, NULL, NULL, NULL},
     {"tiling", (getter)_CtxImage_tiling, NULL, NULL, NULL},

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -185,6 +185,10 @@ class HeifImage(BaseImage):
         pixel_aspect_ratio = c_image.pixel_aspect_ratio
         if pixel_aspect_ratio:
             self.info["pixel_aspect_ratio"] = pixel_aspect_ratio
+        for key in ("content_light_level", "mastering_display_colour_volume", "ambient_viewing_environment"):
+            value = getattr(c_image, key)
+            if value:
+                self.info[key] = value
         tiling = c_image.tiling
         if tiling:
             self.info["tiling"] = tiling
@@ -476,7 +480,13 @@ class HeifFile:
         for key in ["bit_depth", "thumbnails", "icc_profile", "icc_profile_type", "pixel_aspect_ratio", "tiling"]:
             if key in image.info:
                 added_image.info[key] = image.info[key]
-        for key in ["nclx_profile", "metadata"]:
+        for key in [
+            "nclx_profile",
+            "metadata",
+            "content_light_level",
+            "mastering_display_colour_volume",
+            "ambient_viewing_environment",
+        ]:
             if key in image.info:
                 added_image.info[key] = deepcopy(image.info[key])
         added_image.info["exif"] = _exif_from_pillow(image)

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -507,6 +507,7 @@ class CtxEncode:
         pixel_aspect_ratio = kwargs.get("pixel_aspect_ratio")
         if pixel_aspect_ratio:
             grid_handle.set_pixel_aspect_ratio(pixel_aspect_ratio[0], pixel_aspect_ratio[1])
+        self._add_hdr_metadata(grid_handle, **kwargs)
         if kwargs.get("primary"):
             grid_handle.set_primary(self.ctx_write)
         self._add_metadata(grid_handle, **kwargs)
@@ -587,6 +588,8 @@ class CtxEncode:
             *_output_nclx_params(kwargs),
             image_orientation,
         )
+        # set HDR metadata; these are item properties, they require the encoded item handle
+        self._add_hdr_metadata(im_out, **kwargs)
         # adding metadata
         self._add_metadata(im_out, **kwargs)
         # adding thumbnails
@@ -594,6 +597,26 @@ class CtxEncode:
             if max(size) > thumb_box > 3:
                 self._items_count += _items_per_image(mode)
                 im_out.encode_thumbnail(self.ctx_write, thumb_box, image_orientation)
+
+    def _add_hdr_metadata(self, im_out, **kwargs) -> None:
+        clli = kwargs.get("content_light_level")
+        if clli:
+            im_out.set_content_light_level(clli["max_content_light_level"], clli["max_pic_average_light_level"])
+        mdcv = kwargs.get("mastering_display_colour_volume")
+        if mdcv:
+            im_out.set_mastering_display_colour_volume(
+                tuple(mdcv["display_primaries_x"]),
+                tuple(mdcv["display_primaries_y"]),
+                mdcv["white_point_x"],
+                mdcv["white_point_y"],
+                mdcv["max_display_mastering_luminance"],
+                mdcv["min_display_mastering_luminance"],
+            )
+        amve = kwargs.get("ambient_viewing_environment")
+        if amve:
+            im_out.set_ambient_viewing_environment(
+                amve["ambient_illumination"], amve["ambient_light_x"], amve["ambient_light_y"]
+            )
 
     def _add_metadata(self, im_out, **kwargs) -> None:
         exif = kwargs.get("exif")
@@ -625,7 +648,7 @@ class CtxEncode:
 
 
 @dataclass
-class MimCImage:
+class MimCImage:  # pylint: disable=too-many-instance-attributes
     """Mimicry of the HeifImage class."""
 
     def __init__(self, mode: str, size: tuple[int, int], data: bytes, **kwargs):
@@ -642,6 +665,9 @@ class MimCImage:
         self.chroma = HeifChroma.UNDEFINED.value
         self.colorspace = HeifColorspace.UNDEFINED.value
         self.pixel_aspect_ratio = None
+        self.content_light_level = None
+        self.mastering_display_colour_volume = None
+        self.ambient_viewing_environment = None
         self.camera_intrinsic_matrix = None
         self.camera_extrinsic_matrix_rot = None
         self.tiling = None

--- a/tests/metadata_etc_test.py
+++ b/tests/metadata_etc_test.py
@@ -249,6 +249,105 @@ def test_pillow_pixel_aspect_ratio_roundtrip(save_format):
     assert im2.info["pixel_aspect_ratio"] == (4, 3)
 
 
+HDR_CLLI = {"max_content_light_level": 1000, "max_pic_average_light_level": 400}
+HDR_MDCV = {
+    "display_primaries_x": (35400, 8500, 6550),
+    "display_primaries_y": (14600, 39850, 2300),
+    "white_point_x": 15635,
+    "white_point_y": 16450,
+    "max_display_mastering_luminance": 10000000,
+    "min_display_mastering_luminance": 50,
+}
+HDR_AMVE = {"ambient_illumination": 100000, "ambient_light_x": 15635, "ambient_light_y": 16450}
+HDR_KEYS = ("content_light_level", "mastering_display_colour_volume", "ambient_viewing_environment")
+
+
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+def test_heif_hdr_metadata_absent():
+    heif_file = pillow_heif.open_heif(create_heif((64, 64)))
+    for key in HDR_KEYS:
+        assert key not in heif_file[0].info
+
+
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+@pytest.mark.parametrize("save_format", ("HEIF",))
+def test_heif_hdr_metadata_roundtrip(save_format):
+    heif_file = pillow_heif.HeifFile()
+    heif_file.add_from_pillow(Image.effect_mandelbrot((64, 64), (-3, -2.5, 2, 2.5), 100))
+    heif_file[0].info["content_light_level"] = HDR_CLLI
+    heif_file[0].info["mastering_display_colour_volume"] = HDR_MDCV
+    heif_file[0].info["ambient_viewing_environment"] = HDR_AMVE
+    buf1 = BytesIO()
+    heif_file.save(buf1, format=save_format)
+    for box_name in (b"clli", b"mdcv", b"amve"):
+        assert box_name in buf1.getvalue()
+    heif_out1 = pillow_heif.open_heif(buf1)
+    assert heif_out1[0].info["content_light_level"] == HDR_CLLI
+    assert heif_out1[0].info["mastering_display_colour_volume"] == HDR_MDCV
+    assert heif_out1[0].info["ambient_viewing_environment"] == HDR_AMVE
+    buf2 = BytesIO()
+    heif_out1.save(buf2, format=save_format)
+    heif_out2 = pillow_heif.open_heif(buf2)
+    assert heif_out2[0].info["content_light_level"] == HDR_CLLI
+    assert heif_out2[0].info["mastering_display_colour_volume"] == HDR_MDCV
+    assert heif_out2[0].info["ambient_viewing_environment"] == HDR_AMVE
+
+
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+@pytest.mark.parametrize("save_format", ("HEIF",))
+def test_pillow_hdr_metadata_roundtrip(save_format):
+    im = Image.effect_mandelbrot((64, 64), (-3, -2.5, 2, 2.5), 100)
+    buf1 = BytesIO()
+    im.save(
+        buf1,
+        format=save_format,
+        content_light_level=HDR_CLLI,
+        mastering_display_colour_volume=HDR_MDCV,
+        ambient_viewing_environment=HDR_AMVE,
+    )
+    im1 = Image.open(buf1)
+    im1.load()
+    assert im1.info["content_light_level"] == HDR_CLLI
+    assert im1.info["mastering_display_colour_volume"] == HDR_MDCV
+    assert im1.info["ambient_viewing_environment"] == HDR_AMVE
+    buf2 = BytesIO()
+    im1.save(buf2, format=save_format)
+    im2 = Image.open(buf2)
+    im2.load()
+    assert im2.info["content_light_level"] == HDR_CLLI
+    assert im2.info["mastering_display_colour_volume"] == HDR_MDCV
+    assert im2.info["ambient_viewing_environment"] == HDR_AMVE
+
+
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+@pytest.mark.parametrize("save_format", ("HEIF",))
+def test_pillow_hdr_metadata_multiframe(save_format):
+    im1 = Image.effect_mandelbrot((64, 64), (-3, -2.5, 2, 2.5), 100)
+    im1.info["content_light_level"] = HDR_CLLI
+    im2 = Image.effect_mandelbrot((32, 32), (-3, -2.5, 2, 2.5), 100)
+    im2.info["content_light_level"] = {"max_content_light_level": 4000, "max_pic_average_light_level": 1000}
+    out_buf = BytesIO()
+    im1.save(out_buf, format=save_format, save_all=True, append_images=[im2])
+    heif_out = pillow_heif.open_heif(out_buf)
+    assert heif_out[0].info["content_light_level"] == HDR_CLLI
+    assert heif_out[1].info["content_light_level"]["max_content_light_level"] == 4000
+    assert "mastering_display_colour_volume" not in heif_out[0].info
+
+
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+def test_heif_hdr_metadata_grid():
+    heif_file = pillow_heif.HeifFile()
+    heif_file.add_from_pillow(Image.effect_mandelbrot((300, 300), (-3, -2.5, 2, 2.5), 100))
+    heif_file[0].info["content_light_level"] = HDR_CLLI
+    heif_file[0].info["mastering_display_colour_volume"] = HDR_MDCV
+    buf = BytesIO()
+    heif_file.save(buf, tile_size=128)
+    heif_out = pillow_heif.open_heif(buf)
+    assert heif_out[0].info["tiling"]
+    assert heif_out[0].info["content_light_level"] == HDR_CLLI
+    assert heif_out[0].info["mastering_display_colour_volume"] == HDR_MDCV
+
+
 @pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
 @pytest.mark.parametrize("save_format", ("HEIF",))
 def test_pillow_pixel_aspect_ratio_multiframe(save_format):


### PR DESCRIPTION
1. new optional keys in the `info` dictionary: `content_light_level`, `mastering_display_colour_volume`, `ambient_viewing_environment` - filled from the item properties when present, without decoding
2. on save the same keys (or `save()` kwargs) are written back as item properties, for single images and grids; previously all HDR metadata was silently dropped on re-encode
3. values are the raw H.265/ISO code values, so a roundtrip is lossless