### PR TITLE
ci: publish Python 3.15 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,9 +25,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  # cp315/cp315t wheels are built only for testing and are skipped on tag builds,
-  # see the "cpython-prerelease" note in pyproject.toml
-  EXPECTED_DISTS: ${{ startsWith(github.ref, 'refs/tags/') && 54 || 70 }}
+  EXPECTED_DISTS: 70
 
 jobs:
   check-version:
@@ -93,7 +91,7 @@ jobs:
 
       - name: Reduce build to oldest and newest stable Python
         if: github.event_name == 'pull_request'
-        run: echo 'CIBW_BUILD=cp310-* cp314-*' >> "$GITHUB_ENV"
+        run: echo 'CIBW_BUILD=cp310-* cp315-*' >> "$GITHUB_ENV"
 
       - name: Restore dependencies cache
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
@@ -107,7 +105,7 @@ jobs:
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_SKIP: ${{ matrix.libc == 'manylinux' && '*-musllinux*' || '*-manylinux*' }}${{ github.event_name == 'push' && ' cp315-* cp315t-*' || '' }}
+          CIBW_SKIP: ${{ matrix.libc == 'manylinux' && '*-musllinux*' || '*-manylinux*' }}
           CIBW_BEFORE_ALL_LINUX: |
             set -e
             ${{ env.INSTALL_OS_PACKAGES }}
@@ -172,7 +170,7 @@ jobs:
 
       - name: Reduce build to oldest and newest stable Python
         if: github.event_name == 'pull_request'
-        run: echo 'CIBW_BUILD=cp310-* cp314-*' >> "$GITHUB_ENV"
+        run: echo 'CIBW_BUILD=cp310-* cp315-*' >> "$GITHUB_ENV"
 
       - name: Restore dependencies cache
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
@@ -192,10 +190,6 @@ jobs:
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_SKIP: ${{ github.event_name == 'push' && 'cp315-* cp315t-*' || '' }}
-          # No Pillow cp315 wheels on PyPI yet and no way to build it from source in the
-          # test env; remove once Pillow ships cp315 wheels.
-          CIBW_TEST_SKIP: "cp315-macosx* cp315t-macosx*"
           CIBW_ENVIRONMENT_MACOS: >-
             PH_RELEASE_TESTS=1
             ${{ matrix.arch == 'x86_64' && 'TEST_DECODE_THREADS=0' || '' }}
@@ -286,16 +280,12 @@ jobs:
       - name: Reduce build to oldest and newest stable Python
         if: github.event_name == 'pull_request'
         shell: bash
-        run: echo 'CIBW_BUILD=cp310-* cp314-*' >> "$GITHUB_ENV"
+        run: echo 'CIBW_BUILD=cp310-* cp315-*' >> "$GITHUB_ENV"
 
       - name: Run cibuildwheel
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_SKIP: ${{ github.event_name == 'push' && 'cp315-* cp315t-*' || '' }}
-          # No Pillow cp315 wheels on PyPI yet and no way to build it from source in the
-          # test env; remove once Pillow ships cp315 wheels.
-          CIBW_TEST_SKIP: "cp315-win* cp315t-win*"
           CIBW_ENVIRONMENT_WINDOWS: >-
             PH_RELEASE_TESTS=1
             ${{ github.event_name != 'push' && format('COVERAGE_OUT=''{0}/coverage-data''', github.workspace) || '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Reading and writing HDR metadata: `content_light_level`, `mastering_display_colour_volume`, `ambient_viewing_environment` keys in `info` dictionary. #456
+- Python `3.15` and `3.15t` wheels added.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![docs](https://readthedocs.org/projects/pillow-heif/badge/?version=latest)](https://pillow-heif.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/bigcat88/pillow_heif/branch/master/graph/badge.svg?token=JY64F2OL6V)](https://codecov.io/gh/bigcat88/pillow_heif)
 
-![PythonVersion](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)
+![PythonVersion](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14%20%7C%203.15-blue)
 ![impl](https://img.shields.io/pypi/implementation/pillow_heif)
 ![pypi](https://img.shields.io/pypi/v/pillow_heif.svg)
 [![Downloads](https://static.pepy.tech/personalized-badge/pillow-heif?period=total&units=international_system&left_color=grey&right_color=orange&left_text=Downloads)](https://pepy.tech/project/pillow-heif)
@@ -143,6 +143,8 @@ if im.info["depth_images"]:
 | CPython 3.13       |        ✅        |         ✅         |      ✅       |     ✅      |     ✅      |
 | CPython 3.14       |        ✅        |         ✅         |      ✅       |     ✅      |     ✅      |
 | CPython 3.14t      |        ✅        |         ✅         |      ✅       |     ✅      |     ✅      |
+| CPython 3.15       |        ✅        |         ✅         |      ✅       |     ✅      |     ✅      |
+| CPython 3.15t      |        ✅        |         ✅         |      ✅       |     ✅      |     ✅      |
 | PyPy 3.11 v7.3     |        ✅        |         ✅         |      ✅       |    N/A     |     ✅      |
 
 &ast; **x86_64**, **aarch64** wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,7 @@ before-test = [
   "pip install --only-binary=:all: numpy || true",
   "pip install pympler || true",
 ]
-# cp315/cp315t are built for early testing only: wheels.yml skips them on tag builds,
-# as wheels built against a beta CPython ABI must not be published to PyPI.
-# Once 3.15 ABI is stable (rc1+) in cibuildwheel: drop "cpython-prerelease" and the skips.
-enable = [ "pypy", "cpython-prerelease" ]
+enable = [ "pypy" ]
 macos.repair-wheel-command = [
   "DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel}",
   "DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel -v --require-archs {delocate_archs} -w {dest_dir} {wheel}",

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.14
+    Programming Language :: Python :: 3.15
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: MacOS :: MacOS X


### PR DESCRIPTION
1. `cibuildwheel` `4.2.0` builds `cp315`/`cp315t` by default, the `cpython-prerelease` enable and the tag-build skips are no longer needed
2. `Pillow` `12.3.0` ships `cp315`/`cp315t` wheels for every platform we build, so the macOS/Windows `CIBW_TEST_SKIP` is dropped
3. `EXPECTED_DISTS` is a constant `70` again
4. PR builds are reduced to `cp310`/`cp315` instead of `cp310`/`cp314`, `3.15` is the newest stable one now