### PR TITLE
ci: rework flaky memory leak tests

### DIFF
--- a/tests/leaks_test.py
+++ b/tests/leaks_test.py
@@ -1,11 +1,11 @@
 import ctypes
 import gc
+import mmap
 import sys
 from contextlib import suppress
 from io import BytesIO
 from os import chdir, path
 from pathlib import Path
-from platform import machine
 
 import helpers
 import pytest
@@ -16,8 +16,16 @@ import pillow_heif
 pytest.importorskip("pympler", reason="`pympler` not installed")
 pytest.importorskip("numpy", reason="`numpy` not installed")
 
+from pympler.process import ProcessMemoryInfo, is_available
+
 chdir(path.join(path.dirname(path.dirname(path.abspath(__file__))), "tests"))
 pillow_heif.register_heif_opener()
+
+# without a working backend `rss` is always 0, which would make the checks below pass silently
+requires_rss = pytest.mark.skipif(not is_available(), reason="`pympler` cannot measure RSS on this platform")
+requires_refcounting = pytest.mark.skipif(
+    sys.implementation.name != "cpython", reason="memory is not freed deterministically"
+)
 
 
 def perform_open_save(iterations, image_path):
@@ -37,17 +45,19 @@ def perform_open_save(iterations, image_path):
 def test_open_save_objects_leaks(image):
     from pympler import summary, tracker
 
-    image_file_data = BytesIO(Path(image).read_bytes())
-    perform_open_save(1, image_file_data)
+    perform_open_save(1, image)
     gc.collect()
     _summary1 = tracker.SummaryTracker().create_summary()
     _summary1 = tracker.SummaryTracker().create_summary()  # noqa
     gc.collect()
     gc.set_debug(gc.DEBUG_SAVEALL)
-    perform_open_save(5, image_file_data)
-    gc.collect()
-    gc.collect()
-    gc.collect()
+    try:
+        perform_open_save(5, image)
+        gc.collect()
+        gc.collect()
+        gc.collect()
+    finally:
+        gc.set_debug(0)
     summary2 = tracker.SummaryTracker().create_summary()
     results = summary._sweep(summary.get_diff(_summary1, summary2))  # noqa
     if results:
@@ -56,8 +66,6 @@ def test_open_save_objects_leaks(image):
 
 
 def _get_mem_usage() -> float:
-    from pympler.process import ProcessMemoryInfo
-
     if sys.platform == "linux":
         # glibc keeps freed chunks in its arenas, give them back before measuring
         with suppress(OSError, AttributeError):  # AttributeError: musl has no `malloc_trim`
@@ -86,22 +94,42 @@ def _assert_no_mem_growth(iteration, warmup: int, block: int, tolerance: float =
     )
 
 
-@pytest.mark.skipif(sys.platform.lower() in ("win32", "darwin"), reason="run only on Linux")
-@pytest.mark.skipif(machine().find("x86_64") == -1, reason="run only on x86_64")
+@requires_rss
+def test_mem_growth_is_detected():
+    # guards the checks below: they are only meaningful if a leak of this size fails them.
+    # `mmap` is used instead of a plain allocation, as it is not served from the allocator
+    # free lists, that on macOS stay accounted as resident and can hide a small leak.
+    leaked = []
+
+    def iteration():
+        chunk = mmap.mmap(-1, 64 * 1024)
+        chunk.write(b"x" * (64 * 1024))
+        leaked.append(chunk)
+
+    try:
+        with pytest.raises(AssertionError, match="memory usage grew"):
+            _assert_no_mem_growth(iteration, warmup=10, block=100)
+    finally:
+        for chunk in leaked:
+            chunk.close()
+
+
+@requires_rss
+@requires_refcounting
 def test_open_to_numpy_mem_leaks():
     import numpy as np
 
-    image_file_data = BytesIO(Path("images/heif/L_10__29x100.heif").read_bytes())
+    image_path = Path("images/heif/L_10__29x100.heif")
 
     def iteration():
-        heif_file = pillow_heif.open_heif(image_file_data, convert_hdr_to_8bit=False)
+        heif_file = pillow_heif.open_heif(image_path, convert_hdr_to_8bit=False)
         np.asarray(heif_file[0])
 
     _assert_no_mem_growth(iteration, warmup=100, block=1000)
 
 
-@pytest.mark.skipif(sys.platform.lower() in ("win32", "darwin"), reason="run only on Linux")
-@pytest.mark.skipif(machine().find("x86_64") == -1, reason="run only on x86_64")
+@requires_rss
+@requires_refcounting
 @pytest.mark.parametrize(
     "im, cp_type", [("images/heif_other/cat.hif", "NCLX"), ("images/heif_other/arrow.heic", "ICC")]
 )
@@ -111,12 +139,12 @@ def test_color_profile_leaks(im, cp_type):
     def iteration():
         _ = heif_file[0]._c_image.color_profile
 
-    # a leaked color profile is only a few hundred bytes, so it needs many more iterations
-    _assert_no_mem_growth(iteration, warmup=1000, block=20000)
+    # a leaked color profile is small (~50 bytes for NCLX), so it needs many more iterations to show up
+    _assert_no_mem_growth(iteration, warmup=1000, block=100000)
 
 
-@pytest.mark.skipif(sys.platform.lower() in ("win32", "darwin"), reason="run only on Linux")
-@pytest.mark.skipif(machine().find("x86_64") == -1, reason="run only on x86_64")
+@requires_rss
+@requires_refcounting
 def test_metadata_leaks():
     heif_file = pillow_heif.open_heif(Path("images/heif_other/L_exif_xmp_iptc.heic"))
 
@@ -126,13 +154,15 @@ def test_metadata_leaks():
     _assert_no_mem_growth(iteration, warmup=200, block=2000)
 
 
-@pytest.mark.skipif(sys.platform.lower() in ("win32", "darwin"), reason="run only on Linux")
-@pytest.mark.skipif(machine().find("x86_64") == -1, reason="run only on x86_64")
+@requires_rss
+@requires_refcounting
 def test_pillow_plugin_leaks():
-    image_file_data = BytesIO(Path("images/heif/zPug_3.heic").read_bytes())
+    # a `Path` and not a `BytesIO`: `BytesIO.read()` returns the same `bytes` object every time,
+    # which would hide a leaked reference to the file data
+    image_path = Path("images/heif/zPug_3.heic")
 
     def iteration():
-        im = Image.open(image_file_data)
+        im = Image.open(image_path)
         for frame in ImageSequence.Iterator(im):
             frame.load()
 

--- a/tests/leaks_test.py
+++ b/tests/leaks_test.py
@@ -1,5 +1,7 @@
+import ctypes
 import gc
 import sys
+from contextlib import suppress
 from io import BytesIO
 from os import chdir, path
 from pathlib import Path
@@ -53,11 +55,35 @@ def test_open_save_objects_leaks(image):
         raise MemoryError("Potential memory leaks")
 
 
-def _get_mem_usage():
-    from resource import RUSAGE_SELF, getpagesize, getrusage
+def _get_mem_usage() -> float:
+    from pympler.process import ProcessMemoryInfo
 
-    mem = getrusage(RUSAGE_SELF).ru_maxrss
-    return mem * getpagesize() / 1024 / 1024
+    if sys.platform == "linux":
+        # glibc keeps freed chunks in its arenas, give them back before measuring
+        with suppress(OSError, AttributeError):  # AttributeError: musl has no `malloc_trim`
+            ctypes.CDLL(None).malloc_trim(0)
+    return ProcessMemoryInfo().rss / 1024 / 1024
+
+
+def _assert_no_mem_growth(iteration, warmup: int, block: int, tolerance: float = 2.0) -> None:
+    # A leak adds the same amount of memory in every block, while a one-time allocator
+    # growth shows up only once, so the last block is the one that gets measured.
+    for _ in range(warmup):
+        iteration()
+    gc.collect()
+    after_warmup = _get_mem_usage()
+    for _ in range(block):
+        iteration()
+    gc.collect()
+    settled = _get_mem_usage()
+    for _ in range(block):
+        iteration()
+    gc.collect()
+    growth = _get_mem_usage() - settled
+    assert growth <= tolerance, (
+        f"memory usage grew by {growth:.2f} MiB during the last {block} iterations "
+        f"({after_warmup:.2f} MiB after warmup, {settled:.2f} MiB after the first block)"
+    )
 
 
 @pytest.mark.skipif(sys.platform.lower() in ("win32", "darwin"), reason="run only on Linux")
@@ -65,18 +91,13 @@ def _get_mem_usage():
 def test_open_to_numpy_mem_leaks():
     import numpy as np
 
-    mem_limit = None
     image_file_data = BytesIO(Path("images/heif/L_10__29x100.heif").read_bytes())
-    for i in range(700):
+
+    def iteration():
         heif_file = pillow_heif.open_heif(image_file_data, convert_hdr_to_8bit=False)
-        _array = np.asarray(heif_file[0])  # noqa
-        _array = None  # noqa
-        gc.collect()
-        mem = _get_mem_usage()
-        if i < 200:
-            mem_limit = mem + 2
-            continue
-        assert mem <= mem_limit, f"memory usage limit exceeded after {i + 1} iterations"
+        np.asarray(heif_file[0])
+
+    _assert_no_mem_growth(iteration, warmup=100, block=1000)
 
 
 @pytest.mark.skipif(sys.platform.lower() in ("win32", "darwin"), reason="run only on Linux")
@@ -85,50 +106,34 @@ def test_open_to_numpy_mem_leaks():
     "im, cp_type", [("images/heif_other/cat.hif", "NCLX"), ("images/heif_other/arrow.heic", "ICC")]
 )
 def test_color_profile_leaks(im, cp_type):
-    mem_limit = None
     heif_file = pillow_heif.open_heif(Path(im), convert_hdr_to_8bit=False)
-    for i in range(700):
-        _nclx = heif_file[0]._c_image.color_profile  # noqa
-        _nclx = None  # noqa
-        gc.collect()
-        mem = _get_mem_usage()
-        if i < 300:
-            mem_limit = mem + 2
-            continue
-        assert mem <= mem_limit, f"memory usage limit exceeded after {i + 1} iterations. Color profile type:{cp_type}"
+
+    def iteration():
+        _ = heif_file[0]._c_image.color_profile
+
+    # a leaked color profile is only a few hundred bytes, so it needs many more iterations
+    _assert_no_mem_growth(iteration, warmup=1000, block=20000)
 
 
 @pytest.mark.skipif(sys.platform.lower() in ("win32", "darwin"), reason="run only on Linux")
 @pytest.mark.skipif(machine().find("x86_64") == -1, reason="run only on x86_64")
 def test_metadata_leaks():
-    mem_limit = None
     heif_file = pillow_heif.open_heif(Path("images/heif_other/L_exif_xmp_iptc.heic"))
-    for i in range(700):
-        _metadata = heif_file[0]._c_image.metadata  # noqa
-        _metadata = None  # noqa
-        gc.collect()
-        mem = _get_mem_usage()
-        if i < 200:
-            mem_limit = mem + 2
-            continue
-        assert mem <= mem_limit, f"memory usage limit exceeded after {i + 1} iterations"
+
+    def iteration():
+        _ = heif_file[0]._c_image.metadata
+
+    _assert_no_mem_growth(iteration, warmup=200, block=2000)
 
 
 @pytest.mark.skipif(sys.platform.lower() in ("win32", "darwin"), reason="run only on Linux")
 @pytest.mark.skipif(machine().find("x86_64") == -1, reason="run only on x86_64")
 def test_pillow_plugin_leaks():
-    mem_limit = None
     image_file_data = BytesIO(Path("images/heif/zPug_3.heic").read_bytes())
-    for i in range(700):
+
+    def iteration():
         im = Image.open(image_file_data)
         for frame in ImageSequence.Iterator(im):
             frame.load()
-            frame = None  # noqa
-        im = None  # noqa
-        gc.collect()
-        gc.collect()
-        mem = _get_mem_usage()
-        if i < 300:
-            mem_limit = mem + 2
-            continue
-        assert mem <= mem_limit, f"memory usage limit exceeded after {i + 1} iterations"
+
+    _assert_no_mem_growth(iteration, warmup=100, block=300)


### PR DESCRIPTION
1. `ru_maxrss` is a high-water mark and on Linux it is in kilobytes, so multiplying it by the page size made the `+2` budget ~0.5 MiB on a value that can only grow - the [last failure](https://github.com/bigcat88/pillow_heif/actions/runs/31861535442/job/94955895125) was a 0.5 MiB overshoot on the `pypy` wheel, where nothing is freed deterministically
2. current RSS is taken from `pympler`, with `malloc_trim` on glibc first, and instead of a limit from a single sample the same number of iterations is run twice: a leak grows in every block, a one-time allocator growth only in the first one
3. the `Linux`/`x86_64` skips are replaced with what the checks need - a working RSS backend (on Windows `pympler` needs `pywin32`, so there they are skipped) and a refcounting interpreter; `test_mem_growth_is_detected` leaks `6` MiB and requires the check to fail
4. images are read from a `Path`: `BytesIO.read()` returns the same `bytes` object every time, which hides a leaked reference to the file data; the color profile needs `100000` iterations, as a leaked `nclx` struct is only ~50 bytes