### PR TITLE
docs: fix the docs build and refresh the reference

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,11 @@ on:
       - 'libheif/build_libs.py'
       - 'pillow_heif/*.*'
       - 'tests/**'
+      - 'docs/**'
       - 'setup.*'
       - 'pyproject.toml'
       - '.pre-commit-config.yaml'
+      - '.readthedocs.yml'
   push:
     branches: [master]
     paths:
@@ -17,9 +19,11 @@ on:
       - 'libheif/build_libs.py'
       - 'pillow_heif/*.*'
       - 'tests/**'
+      - 'docs/**'
       - 'setup.*'
       - 'pyproject.toml'
       - '.pre-commit-config.yaml'
+      - '.readthedocs.yml'
   workflow_dispatch:
 
 permissions:
@@ -70,6 +74,27 @@ jobs:
 
       - name: Run Analysis
         run: python3 -m pylint "setup.py" "pillow_heif/"
+
+  docs:
+    runs-on: ubuntu-24.04
+    name: Docs
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Install from source
+        # "READTHEDOCS" makes `setup.py` skip the C extension, exactly as the docs are built on Read the Docs
+        env:
+          READTHEDOCS: "True"
+        run: python3 -m pip install ".[docs]"
+
+      - name: Build docs
+        run: python3 -m sphinx -b html -W --keep-going docs docs/_build
 
   pillow-dev:
     runs-on: ubuntu-24.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.14"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,14 +15,12 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../."))
 
-import sphinx_rtd_theme  # noqa
-
 import pillow_heif  # noqa
 
 # -- Project information -----------------------------------------------------
 
 project = "pillow-heif"
-copyright = "2021-2022, Alexander Piskun and Contributors"  # noqa
+copyright = "2021-2026, Alexander Piskun and Contributors"  # noqa
 author = "Alexander Piskun and Contributors"
 
 # The short X.Y version.
@@ -78,7 +76,6 @@ nitpicky = True
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_logo = "resources/pillow-heif-logo.png"
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -6,11 +6,13 @@ Options
 .. autodata:: pillow_heif.options.DECODE_THREADS
 .. autodata:: pillow_heif.options.THUMBNAILS
 .. autodata:: pillow_heif.options.DEPTH_IMAGES
+.. autodata:: pillow_heif.options.AUX_IMAGES
 .. autodata:: pillow_heif.options.QUALITY
 .. autodata:: pillow_heif.options.SAVE_HDR_TO_12_BIT
 .. autodata:: pillow_heif.options.SAVE_NCLX_PROFILE
 .. autodata:: pillow_heif.options.PREFERRED_ENCODER
 .. autodata:: pillow_heif.options.PREFERRED_DECODER
+.. autodata:: pillow_heif.options.DISABLE_SECURITY_LIMITS
 .. autodata:: pillow_heif.options.GRID_TILE_SIZE
 
 Example of use

--- a/docs/reference/HeifImage.rst
+++ b/docs/reference/HeifImage.rst
@@ -8,20 +8,17 @@ HeifImage object
     :inherited-members:
     :members:
 
-    .. py:attribute:: info["exif"]
-        :type: bytes
+    .. describe:: info["exif"]: bytes
 
         .. note:: In HEIF `orientation` tag is only for information purposes and must not be used to rotate image.
 
         EXIF metadata. Can be `None`
 
-    .. py:attribute:: info["xmp"]
-        :type: bytes
+    .. describe:: info["xmp"]: bytes
 
         XMP metadata. String in bytes in UTF-8 encoding. Absent if `xmp` data is missing.
 
-    .. py:attribute:: info["metadata"]
-        :type: list[dict]
+    .. describe:: info["metadata"]: list[dict]
 
         Other metadata(IPTC for example). List of dictionaries. Usual will be empty. Keys:
 
@@ -29,35 +26,34 @@ HeifImage object
             * `content_type`: str
             * `data`: bytes
 
-    .. py:attribute:: info["primary"]
-        :type: bool
+    .. describe:: info["primary"]: bool
 
         A boolean value that specifies whether the image is the main image when the file
         contains more than one image.
 
-    .. py:attribute:: info["bit_depth"]
-        :type: int
+    .. describe:: info["bit_depth"]: int
 
         Shows the bit-depth of image in file(not the decoded one, so it may differs from bit depth of mode).
         Possible values: 8, 10 and 12.
 
-    .. py:attribute:: info["thumbnails"]
-        :type: list[int]
+    .. describe:: info["chroma"]: int
+
+        Chroma subsampling of the image in file. Possible values: 420, 422 and 444.
+        Absent for monochrome images.
+
+    .. describe:: info["thumbnails"]: list[int]
 
         List of thumbnail boxes sizes. Can be empty.
 
-    .. py:attribute:: info["icc_profile"]
-        :type: bytes
+    .. describe:: info["icc_profile"]: bytes
 
         ICC Profile. Can be absent. Can be empty.
 
-    .. py:attribute:: info["icc_profile_type"]
-        :type: str
+    .. describe:: info["icc_profile_type"]: str
 
         Possible values: ``prof`` or ``rICC``. Can be absent.
 
-    .. py:attribute:: info["nclx_profile"]
-        :type: dict
+    .. describe:: info["nclx_profile"]: dict
 
         NCLX color profile. Can be absent. Keys:
 
@@ -66,16 +62,14 @@ HeifImage object
             * `matrix_coefficients`: :py:class:`HeifMatrixCoefficients`
             * `full_range_flag`: `bool`
 
-    .. py:attribute:: info["content_light_level"]
-        :type: dict
+    .. describe:: info["content_light_level"]: dict
 
         Content light level information(``clli``). Can be absent. Keys:
 
             * `max_content_light_level`: `int`
             * `max_pic_average_light_level`: `int`
 
-    .. py:attribute:: info["mastering_display_colour_volume"]
-        :type: dict
+    .. describe:: info["mastering_display_colour_volume"]: dict
 
         Mastering display colour volume(``mdcv``). Can be absent. Keys:
 
@@ -86,8 +80,7 @@ HeifImage object
             * `max_display_mastering_luminance`: `int`
             * `min_display_mastering_luminance`: `int`
 
-    .. py:attribute:: info["ambient_viewing_environment"]
-        :type: dict
+    .. describe:: info["ambient_viewing_environment"]: dict
 
         Ambient viewing environment(``amve``). Can be absent. Keys:
 
@@ -99,14 +92,24 @@ HeifImage object
             Like ``nclx_profile`` and ``icc_profile`` they are written back during save;
             remove a key from ``info`` if you do not want it in the output file.
 
-    .. py:attribute:: info["depth_images"]
-        :type: list
+    .. describe:: info["pixel_aspect_ratio"]: tuple[int, int]
+
+        Pixel aspect ratio(``pasp``) as ``(horizontal_spacing, vertical_spacing)``.
+        Absent when the image has no ``pasp`` box. It is written back during save.
+
+    .. describe:: info["depth_images"]: list
 
         List of :py:class:`~pillow_heif.heif.HeifDepthImage` if any present for image.
         Currently `libheif` does not support writing of them, only reading.
 
-    .. py:attribute:: info["tiling"]
-        :type: dict
+    .. describe:: info["aux"]: dict
+
+        Auxiliary images present for the image. Keys are the auxiliary types, e.g.
+        ``urn:com:apple:photo:2020:aux:hdrgainmap``, values are lists of IDs to pass to
+        :py:meth:`~pillow_heif.HeifImage.get_aux_image`. Empty when the image has no auxiliary images.
+        Currently `libheif` does not support writing of them, only reading.
+
+    .. describe:: info["tiling"]: dict
 
         Tiling information when the image is stored as a grid of tiles. Absent for non-tiled images.
         All values are in the display space, the same as ``size``. Keys:
@@ -118,6 +121,16 @@ HeifImage object
             * `image_width`: `int`
             * `image_height`: `int`
 
+    .. describe:: info["heif"]: dict
+
+        Camera matrices of the image, present only when the file contains them. Keys:
+
+            * `camera_intrinsic_matrix`: `dict` with `focal_length_x`, `focal_length_y`,
+              `principal_point_x`, `principal_point_y` and `skew`
+            * `camera_extrinsic_matrix_rot`: `tuple` of nine `float`, the rotation matrix
+
+        .. note:: These values are currently not written back during save.
+
 .. autoclass:: pillow_heif.heif.BaseImage
     :show-inheritance:
     :inherited-members:
@@ -128,9 +141,13 @@ HeifImage object
     :inherited-members:
     :members:
 
-    .. py:attribute:: info["metadata"]
-        :type: dict
+    .. describe:: info["metadata"]: dict
 
         Represents `libheif` ``heif_depth_representation_info`` struct as a dictionary.
 
         If someone have an example when this struct got filled let me know.
+
+.. autoclass:: pillow_heif.heif.HeifAuxImage
+    :show-inheritance:
+    :inherited-members:
+    :members:

--- a/docs/reference/HeifImagePlugin.rst
+++ b/docs/reference/HeifImagePlugin.rst
@@ -22,9 +22,17 @@ HeifImageFile object
             They are the same as in :py:class:`~pillow_heif.HeifImage` class.
 
         Specific keys for this plugin that is always present are:
-            exif, xmp, metadata, primary, bit_depth, thumbnails
+            exif, metadata, primary, bit_depth, thumbnails, depth_images, aux, original_orientation
         Optional there can be also such keys:
-            icc_profile, icc_profile_type, nclx_profile, tiling
+            xmp, chroma, icc_profile, icc_profile_type, nclx_profile, content_light_level,
+            mastering_display_colour_volume, ambient_viewing_environment, pixel_aspect_ratio,
+            tiling, heif
+
+    .. describe:: info["original_orientation"]: int
+
+        Orientation that the ``EXIF``/``XMP`` tags had in the file, or ``None`` when there was none.
+        The plugin calls :py:func:`~pillow_heif.set_orientation` for every image, so the tags
+        themselves are already reset when the image is opened, see :doc:`/workaround-orientation`.
 
     .. py:method:: get_format_mimetype
 

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -236,7 +236,7 @@ class HeifImage(BaseImage):
     def get_aux_image(self, aux_id: int) -> HeifAuxImage:
         """Method to retrieve the auxiliary image at the given ID.
 
-        :returns: a :py:class:`~pillow_heif.HeifAuxImage` class instance.
+        :returns: a :py:class:`~pillow_heif.heif.HeifAuxImage` class instance.
         """
         aux_image = self._c_image.get_aux_image(aux_id)
         return HeifAuxImage(aux_image)


### PR DESCRIPTION
Read the Docs builds have failed since `1.2.0`: the config pins python `3.9` while the package requires `>=3.10`, so nothing has been published since 2026-01-22 ([build log](https://app.readthedocs.org/projects/pillow-heif/builds/32125017/)).

1. `.readthedocs.yml`: `ubuntu-24.04` + python `3.14`.
2. `info[...]` keys were rendered as `info[]` — the key name is eaten by the python domain. Switched to `.. describe::`.
3. Documented what was missing: `chroma`, `pixel_aspect_ratio`, `aux`, `heif` and `original_orientation` info keys, `AUX_IMAGES` and `DISABLE_SECURITY_LIMITS` options, `HeifAuxImage` class.
4. `conf.py`: dropped the deprecated `get_html_theme_path` call.
5. New `Docs` CI job builds with `-W`, so a broken docs build fails a PR instead of rotting for months. It does not need `libheif`.