### PR TITLE
feat: zero-copy decoding into Pillow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,6 +159,53 @@ jobs:
           flags: pillow-dev
           fail_ci_if_error: false
 
+  pillow-floor:
+    runs-on: ubuntu-24.04
+    name: Pillow-floor
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # the oldest supported Python together with the oldest supported Pillow
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.10'
+
+      - name: Restore dependencies cache
+        id: deps-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/ph-deps
+          key: deps-test-plugins-${{ hashFiles('libheif/build_libs.py', '.github/workflows/test.yml') }}
+
+      - name: Install Libheif
+        run: |
+          sudo apt update && sudo apt -y install nasm libaom-dev
+          sudo BUILD_DIR="${{ runner.temp }}/ph-deps" PH_LIBHEIF_CMAKE_ARGS="$PH_LIBHEIF_CMAKE_ARGS" python3 libheif/build_libs.py
+
+      - name: Save dependencies cache
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/ph-deps
+          key: deps-test-plugins-${{ hashFiles('libheif/build_libs.py', '.github/workflows/test.yml') }}
+
+      - name: Install from source
+        run: |
+          FLOOR=$(sed -n 's/.*pillow>=\([0-9][0-9.]*\).*/\1/p' setup.cfg)
+          echo "PILLOW_FLOOR=$FLOOR" >> "$GITHUB_ENV"
+          python3 -m pip -v install ".[tests]" "pillow==$FLOOR"
+
+      - name: Pillow version check
+        run: python3 -c "import os, PIL; assert PIL.__version__ == os.environ['PILLOW_FLOOR'], PIL.__version__"
+
+      - name: LibHeif info
+        run: python3 -c "import pillow_heif; print(pillow_heif.libheif_info())"
+
+      - name: Run tests
+        run: python3 -m pytest
+
   import-error:
     runs-on: macos-26
     name: ImportError

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 
 - Reading and writing HDR metadata: `content_light_level`, `mastering_display_colour_volume`, `ambient_viewing_environment` keys in `info` dictionary. #456
 - Python `3.15` and `3.15t` wheels added.
+- `HeifImage`, `HeifDepthImage` and `HeifAuxImage` implement the `Arrow C data interface`, so the decoded
+  data can be given to `Pillow`, `PyArrow` or any other consumer of it without a copy.
+- `pillow_layout` option for `open_heif`/`read_heif`: images are decoded in the layout `Pillow` uses internally
+  and `to_pillow` shares the decoded data with the created image instead of copying it.
+
+### Changed
+
+- Pillow plugin no longer copies the decoded image: it is given to `Pillow` as is, which lowers peak memory usage by about a third for large images.
+  Such an image is read-only until it is changed, so `im.load()[x, y] = value` now raises `ValueError`.
+  Every other way of changing an image(`putpixel`, `paste`, `ImageDraw`, ...) copies it first and keeps working.
+- Minimum required `Pillow` version is `11.3.0`.
 
 ### Fixed
 

--- a/docs/reference/HeifImage.rst
+++ b/docs/reference/HeifImage.rst
@@ -131,6 +131,34 @@ HeifImage object
 
         .. note:: These values are currently not written back during save.
 
+Arrow C data interface
+----------------------
+
+Images decoded from a file implement the `Arrow PyCapsule interface
+<https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html>`_:
+:py:class:`~pillow_heif.HeifImage`, :py:class:`~pillow_heif.heif.HeifDepthImage` and
+:py:class:`~pillow_heif.heif.HeifAuxImage` can be given to ``Image.fromarrow``, ``pyarrow.array``
+or any other Arrow consumer without copying the decoded data. This is also what
+:py:meth:`~pillow_heif.HeifImage.to_pillow` uses to share the decoded plane with the created
+image when the file was opened with the ``pillow_layout`` option.
+
+The exported array is flat: `width * height * channels` values of ``uint8``, where an 8-bit
+``RGB`` image decoded with ``pillow_layout`` has four values per pixel with the fourth one unused.
+16-bit images are exported as ``int16`` — the format `Pillow` itself uses for ``I;16`` images —
+so an Arrow consumer that does arithmetic on the values should reinterpret them as ``uint16``,
+otherwise values above `32767` will be read as negative.
+
+.. note:: `Pillow` has no 16-bit multichannel modes, so of the 16-bit images only the single
+    channel ``I;16`` ones can be given to it; ``RGB;16``/``RGBA;16`` images export the same way,
+    but for consumers like `PyArrow`.
+
+The consumer must treat the data as read-only, and the data keeps the decoded image alive for
+as long as it is used. When an image was decoded with ``remove_stride=False`` and its rows got
+padded, there is no flat data to export and ``ValueError`` is raised.
+
+.. automethod:: pillow_heif.HeifImage.__arrow_c_schema__
+.. automethod:: pillow_heif.HeifImage.__arrow_c_array__
+
 .. autoclass:: pillow_heif.heif.BaseImage
     :show-inheritance:
     :inherited-members:

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -19,6 +19,46 @@
 #define MUTEX_UNLOCK(m)
 #endif
 
+/* =========== Arrow C data interface ======== */
+
+#include <stdint.h>
+
+/* Struct definitions from https://arrow.apache.org/docs/format/CDataInterface.html
+   (Apache Arrow project, Apache License 2.0), which is meant to be copied verbatim
+   into projects implementing the interface. */
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+struct ArrowSchema {
+    const char* format;
+    const char* name;
+    const char* metadata;
+    int64_t flags;
+    int64_t n_children;
+    struct ArrowSchema** children;
+    struct ArrowSchema* dictionary;
+
+    void (*release)(struct ArrowSchema*);
+    void* private_data;
+};
+
+struct ArrowArray {
+    int64_t length;
+    int64_t null_count;
+    int64_t offset;
+    int64_t n_buffers;
+    int64_t n_children;
+    const void** buffers;
+    struct ArrowArray** children;
+    struct ArrowArray* dictionary;
+
+    void (*release)(struct ArrowArray*);
+    void* private_data;
+};
+
+#endif  // ARROW_C_DATA_INTERFACE
+
 /* =========== Common stuff ======== */
 
 #define MAX_ENCODERS 20
@@ -98,6 +138,7 @@ typedef struct {
     int alpha;                                  // one of: 0, 1.
     char mode[8];                               // one of: L, RGB, RGBA, RGBa, BGR, BGRA, BGRa + Optional[;10/12/16]
     int n_channels;                             // 1, 2, 3, 4.
+    int plane_channels;                         // components in the decoded plane, 4 instead of 3 for `pillow_layout`
     int primary;                                // one of: 0, 1.
     enum heif_colorspace colorspace;
     enum heif_chroma chroma;
@@ -105,6 +146,7 @@ typedef struct {
     int bgr_mode;                               // private. decode option.
     int remove_stride;                          // private. decode option.
     int hdr_to_16bit;                           // private. decode option.
+    int pillow_layout;                          // private. decode option.
     char decoder_id[64];                        // private. decode option. optional
     struct heif_image_handle *handle;           // private
     struct heif_image *heif_image;              // private
@@ -119,11 +161,21 @@ typedef struct {
 
 static PyTypeObject CtxImage_Type;
 
+int get_bytes_in_cc(CtxImageObject *ctx_image) {
+    return ((ctx_image->bits == 8) || (ctx_image->hdr_to_8bit)) ? 1 : 2;
+}
+
+// Pillow keeps every multi-band image as four bytes per pixel, so with `pillow_layout` an
+// 8-bit RGB image is decoded to RGBA to get a plane Pillow can borrow without a copy.
+void set_plane_channels(CtxImageObject *ctx_image) {
+    ctx_image->plane_channels = ctx_image->n_channels;
+    if (ctx_image->pillow_layout && !ctx_image->bgr_mode
+        && (ctx_image->n_channels == 3) && (get_bytes_in_cc(ctx_image) == 1))
+        ctx_image->plane_channels = 4;
+}
+
 int get_stride(CtxImageObject *ctx_image) {
-    int stride = ctx_image->width * ctx_image->n_channels;
-    if ((ctx_image->bits > 8) && (!ctx_image->hdr_to_8bit))
-        stride = stride * 2;
-    return stride;
+    return ctx_image->width * ctx_image->plane_channels * get_bytes_in_cc(ctx_image);
 }
 
 /* =========== CtxWriteImage ======== */
@@ -960,7 +1012,7 @@ static const char* _colorspace_to_str(enum heif_colorspace colorspace) {
 }
 
 PyObject* _CtxAuxImage(struct heif_image_handle* main_handle, heif_item_id aux_image_id,
-                       int remove_stride, int hdr_to_16bit, PyObject* file_bytes,
+                       int remove_stride, int hdr_to_16bit, int pillow_layout, PyObject* file_bytes,
                        const char* decoder_id) {
     struct heif_image_handle* aux_handle;
     if (check_error(heif_image_handle_get_auxiliary_image_handle(main_handle, aux_image_id, &aux_handle))) {
@@ -1025,7 +1077,9 @@ PyObject* _CtxAuxImage(struct heif_image_handle* main_handle, heif_item_id aux_i
     ctx_image->data = NULL;
     ctx_image->remove_stride = remove_stride;
     ctx_image->hdr_to_16bit = hdr_to_16bit;
+    ctx_image->pillow_layout = pillow_layout;
     ctx_image->file_bytes = file_bytes;
+    set_plane_channels(ctx_image);
     ctx_image->stride = get_stride(ctx_image);
     strcpy(ctx_image->decoder_id, decoder_id);
 #ifdef Py_GIL_DISABLED
@@ -1038,7 +1092,7 @@ PyObject* _CtxAuxImage(struct heif_image_handle* main_handle, heif_item_id aux_i
 /* =========== CtxDepthImage ======== */
 
 PyObject* _CtxDepthImage(struct heif_image_handle* main_handle, heif_item_id depth_image_id,
-                         int remove_stride, int hdr_to_16bit, PyObject* file_bytes,
+                         int remove_stride, int hdr_to_16bit, int pillow_layout, PyObject* file_bytes,
                          const char* decoder_id) {
     struct heif_image_handle* depth_handle;
     if (check_error(heif_image_handle_get_depth_image_handle(main_handle, depth_image_id, &depth_handle))) {
@@ -1078,7 +1132,9 @@ PyObject* _CtxDepthImage(struct heif_image_handle* main_handle, heif_item_id dep
     ctx_image->data = NULL;
     ctx_image->remove_stride = remove_stride;
     ctx_image->hdr_to_16bit = hdr_to_16bit;
+    ctx_image->pillow_layout = pillow_layout;
     ctx_image->file_bytes = file_bytes;
+    set_plane_channels(ctx_image);
     ctx_image->stride = get_stride(ctx_image);
     strcpy(ctx_image->decoder_id, decoder_id);
 #ifdef Py_GIL_DISABLED
@@ -1102,7 +1158,7 @@ static void _CtxImage_destructor(CtxImageObject* self) {
 }
 
 PyObject* _CtxImage(struct heif_image_handle* handle, int hdr_to_8bit,
-                    int bgr_mode, int remove_stride, int hdr_to_16bit,
+                    int bgr_mode, int remove_stride, int hdr_to_16bit, int pillow_layout,
                     int primary, PyObject* file_bytes,
                     const char *decoder_id,
                     enum heif_colorspace colorspace, enum heif_chroma chroma
@@ -1160,10 +1216,12 @@ PyObject* _CtxImage(struct heif_image_handle* handle, int hdr_to_8bit,
     ctx_image->data = NULL;
     ctx_image->remove_stride = remove_stride;
     ctx_image->hdr_to_16bit = hdr_to_16bit;
+    ctx_image->pillow_layout = pillow_layout;
     ctx_image->primary = primary;
     ctx_image->colorspace = colorspace;
     ctx_image->chroma = chroma;
     ctx_image->file_bytes = file_bytes;
+    set_plane_channels(ctx_image);
     ctx_image->stride = get_stride(ctx_image);
     strcpy(ctx_image->decoder_id, decoder_id);
 #ifdef Py_GIL_DISABLED
@@ -1399,18 +1457,13 @@ int decode_image(CtxImageObject* self) {
         channel = heif_channel_interleaved;
         colorspace = heif_colorspace_RGB;
         if ((self->bits == 8) || (self->hdr_to_8bit)) {
-            chroma = self->alpha ? heif_chroma_interleaved_RGBA : heif_chroma_interleaved_RGB;
+            chroma = self->plane_channels == 4 ? heif_chroma_interleaved_RGBA : heif_chroma_interleaved_RGB;
         }
         else {
             chroma = self->alpha ? heif_chroma_interleaved_RRGGBBAA_LE : heif_chroma_interleaved_RRGGBB_LE;
         }
     }
-    if ((self->bits == 8) || (self->hdr_to_8bit)) {
-        bytes_in_cc = 1;
-    }
-    else {
-        bytes_in_cc = 2;
-    }
+    bytes_in_cc = get_bytes_in_cc(self);
 
     if (strlen(self->decoder_id) > 0) {
         decode_options->decoder_id = self->decoder_id;
@@ -1440,16 +1493,16 @@ int decode_image(CtxImageObject* self) {
 
     if ((self->bgr_mode) && (!remove_stride))
         postprocess__bgr(self->width, self->height, self->data, stride,
-                         bytes_in_cc, self->n_channels, shift_size);
+                         bytes_in_cc, self->plane_channels, shift_size);
     else if ((self->bgr_mode) && (remove_stride))
         postprocess__bgr_stride(self->width, self->height, self->data, stride, self->stride,
-                                bytes_in_cc, self->n_channels, shift_size);
+                                bytes_in_cc, self->plane_channels, shift_size);
     else if ((!self->bgr_mode) && (!remove_stride))
         postprocess(self->width, self->height, self->data, stride,
-                    bytes_in_cc, self->n_channels, shift_size);
+                    bytes_in_cc, self->plane_channels, shift_size);
     else if ((!self->bgr_mode) && (remove_stride))
         postprocess__stride(self->width, self->height, self->data, stride, self->stride,
-                            bytes_in_cc, self->n_channels, shift_size);
+                            bytes_in_cc, self->plane_channels, shift_size);
     else {
         PyErr_SetString(PyExc_ValueError, "internal error, invalid postprocess condition");
         return 0;
@@ -1488,6 +1541,122 @@ static PyObject* _CtxImage_data(CtxImageObject* self, void* closure) {
     return PyMemoryView_FromObject((PyObject*)self);
 }
 
+static PyObject* _CtxImage_plane_channels(CtxImageObject* self, void* closure) {
+    return PyLong_FromLong(self->plane_channels);
+}
+
+static PyObject* _CtxImage_pillow_layout(CtxImageObject* self, void* closure) {
+    return PyLong_FromLong(self->pillow_layout);
+}
+
+/* =========== CtxImage: Arrow C data interface ======== */
+
+// "C" is uint8 and "s" is int16; they match the `arrow_band_format` Pillow uses for the
+// modes a plane of that element size can be borrowed into.
+static const char* arrow_format(CtxImageObject* self) {
+    return get_bytes_in_cc(self) == 2 ? "s" : "C";
+}
+
+static void arrow_schema_release(struct ArrowSchema* schema) {
+    schema->release = NULL;  // `format` and `name` are static strings, nothing to free
+}
+
+static void arrow_array_release(struct ArrowArray* array) {
+    PyGILState_STATE gil_state = PyGILState_Ensure();
+    free((void*)array->buffers);
+    array->buffers = NULL;
+    Py_XDECREF((PyObject*)array->private_data);
+    array->private_data = NULL;
+    array->release = NULL;
+    PyGILState_Release(gil_state);
+}
+
+static void arrow_schema_capsule_destructor(PyObject* capsule) {
+    struct ArrowSchema* schema = (struct ArrowSchema*)PyCapsule_GetPointer(capsule, "arrow_schema");
+    if (!schema) {
+        PyErr_Clear();
+        return;
+    }
+    if (schema->release)
+        schema->release(schema);
+    free(schema);
+}
+
+static void arrow_array_capsule_destructor(PyObject* capsule) {
+    struct ArrowArray* array = (struct ArrowArray*)PyCapsule_GetPointer(capsule, "arrow_array");
+    if (!array) {
+        PyErr_Clear();
+        return;
+    }
+    if (array->release)
+        array->release(array);
+    free(array);
+}
+
+static PyObject* _CtxImage_arrow_schema(CtxImageObject* self, PyObject* args) {
+    struct ArrowSchema* schema = (struct ArrowSchema*)calloc(1, sizeof(struct ArrowSchema));
+    if (!schema)
+        return PyErr_NoMemory();
+    schema->format = arrow_format(self);
+    schema->name = "";
+    schema->release = arrow_schema_release;
+    PyObject* capsule = PyCapsule_New(schema, "arrow_schema", arrow_schema_capsule_destructor);
+    if (!capsule)
+        free(schema);
+    return capsule;
+}
+
+static PyObject* _CtxImage_arrow_array(CtxImageObject* self, PyObject* args) {
+    MUTEX_LOCK(&self->decode_mutex);
+    if (!self->data) {
+        if (!decode_image(self)) {
+            MUTEX_UNLOCK(&self->decode_mutex);
+            return NULL;
+        }
+    }
+    MUTEX_UNLOCK(&self->decode_mutex);
+
+    // an Arrow array is a flat sequence of elements, so rows must follow each other without padding
+    if (self->stride != get_stride(self)) {
+        PyErr_SetString(PyExc_ValueError, "decoded image rows are padded, use the `data` property instead");
+        return NULL;
+    }
+
+    struct ArrowArray* array = (struct ArrowArray*)calloc(1, sizeof(struct ArrowArray));
+    if (!array)
+        return PyErr_NoMemory();
+    array->buffers = (const void**)calloc(2, sizeof(void*));
+    if (!array->buffers) {
+        free(array);
+        return PyErr_NoMemory();
+    }
+    array->length = (int64_t)self->width * self->height * self->plane_channels;
+    array->n_buffers = 2;
+    array->buffers[0] = NULL;  // no nulls, the validity bitmap is omitted
+    array->buffers[1] = self->data;
+    array->release = arrow_array_release;
+    array->private_data = self;  // the array keeps the CtxImage, and with it the plane, alive
+    Py_INCREF(self);
+
+    PyObject* schema_capsule = _CtxImage_arrow_schema(self, NULL);
+    if (!schema_capsule) {
+        arrow_array_release(array);
+        free(array);
+        return NULL;
+    }
+    PyObject* array_capsule = PyCapsule_New(array, "arrow_array", arrow_array_capsule_destructor);
+    if (!array_capsule) {
+        Py_DECREF(schema_capsule);
+        arrow_array_release(array);
+        free(array);
+        return NULL;
+    }
+    PyObject* result = PyTuple_Pack(2, schema_capsule, array_capsule);
+    Py_DECREF(schema_capsule);
+    Py_DECREF(array_capsule);
+    return result;
+}
+
 static PyObject* _CtxImage_depth_image_list(CtxImageObject* self, void* closure) {
     int n_images = heif_image_handle_get_number_of_depth_images(self->handle);
     if (n_images == 0)
@@ -1505,8 +1674,8 @@ static PyObject* _CtxImage_depth_image_list(CtxImageObject* self, void* closure)
 
     for (int i = 0; i < n_images; i++) {
         PyObject* ctx_depth_image = _CtxDepthImage(
-            self->handle, images_ids[i], self->remove_stride, self->hdr_to_16bit, self->file_bytes,
-            self->decoder_id);
+            self->handle, images_ids[i], self->remove_stride, self->hdr_to_16bit, self->pillow_layout,
+            self->file_bytes, self->decoder_id);
         if (!ctx_depth_image) {
             Py_DECREF(images_list);
             free(images_ids);
@@ -1543,8 +1712,8 @@ static PyObject* _CtxImage_aux_image_ids(CtxImageObject* self, void* closure) {
 static PyObject* _CtxImage_get_aux_image(CtxImageObject* self, PyObject* arg_image_id) {
     heif_item_id aux_image_id = (heif_item_id)PyLong_AsUnsignedLong(arg_image_id);
     return _CtxAuxImage(
-        self->handle, aux_image_id, self->remove_stride, self->hdr_to_16bit, self->file_bytes,
-        self->decoder_id
+        self->handle, aux_image_id, self->remove_stride, self->hdr_to_16bit, self->pillow_layout,
+        self->file_bytes, self->decoder_id
     );
 }
 
@@ -1681,6 +1850,8 @@ static struct PyGetSetDef _CtxImage_getseters[] = {
     {"thumbnails", (getter)_CtxImage_thumbnails, NULL, NULL, NULL},
     {"stride", (getter)_CtxImage_stride, NULL, NULL, NULL},
     {"data", (getter)_CtxImage_data, NULL, NULL, NULL},
+    {"plane_channels", (getter)_CtxImage_plane_channels, NULL, NULL, NULL},
+    {"pillow_layout", (getter)_CtxImage_pillow_layout, NULL, NULL, NULL},
     {"depth_image_list", (getter)_CtxImage_depth_image_list, NULL, NULL, NULL},
     {"aux_image_ids", (getter)_CtxImage_aux_image_ids, NULL, NULL, NULL},
     {"pixel_aspect_ratio", (getter)_CtxImage_pixel_aspect_ratio, NULL, NULL, NULL},
@@ -1696,6 +1867,8 @@ static struct PyGetSetDef _CtxImage_getseters[] = {
 static struct PyMethodDef _CtxImage_methods[] = {
     {"get_aux_image", (PyCFunction)_CtxImage_get_aux_image, METH_O},
     {"get_aux_type", (PyCFunction)_CtxImage_get_aux_type, METH_O},
+    {"__arrow_c_schema__", (PyCFunction)_CtxImage_arrow_schema, METH_VARARGS},
+    {"__arrow_c_array__", (PyCFunction)_CtxImage_arrow_array, METH_VARARGS},
     {NULL, NULL}
 };
 
@@ -1752,11 +1925,12 @@ static PyObject* _CtxWrite(PyObject* self, PyObject* args) {
 
 static PyObject* _load_file(PyObject* self, PyObject* args) {
     int hdr_to_8bit, threads_count, bgr_mode, remove_stride, hdr_to_16bit, disable_security_limits;
+    int pillow_layout;
     PyObject *heif_bytes;
     const char *decoder_id;
 
     if (!PyArg_ParseTuple(args,
-                          "Oiiiiisi",
+                          "Oiiiiisii",
                           &heif_bytes,
                           &threads_count,
                           &hdr_to_8bit,
@@ -1764,7 +1938,8 @@ static PyObject* _load_file(PyObject* self, PyObject* args) {
                           &remove_stride,
                           &hdr_to_16bit,
                           &decoder_id,
-                          &disable_security_limits))
+                          &disable_security_limits,
+                          &pillow_layout))
         return NULL;
 
     struct heif_context* heif_ctx = heif_context_alloc();
@@ -1817,8 +1992,8 @@ static PyObject* _load_file(PyObject* self, PyObject* args) {
             error = heif_image_handle_get_preferred_decoding_colorspace(handle, &colorspace, &chroma);
             if (error.code == heif_error_Ok) {
                 PyObject* ctx_image = _CtxImage(
-                    handle, hdr_to_8bit, bgr_mode, remove_stride, hdr_to_16bit, primary, heif_bytes,
-                    decoder_id, colorspace, chroma);
+                    handle, hdr_to_8bit, bgr_mode, remove_stride, hdr_to_16bit, pillow_layout, primary,
+                    heif_bytes, decoder_id, colorspace, chroma);
                 if (!ctx_image) {
                     Py_DECREF(images_list);
                     heif_image_handle_release(handle);

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -8,7 +8,7 @@ from PIL import Image, ImageFile, ImageSequence
 
 from . import options
 from .constants import HeifCompressionFormat
-from .heif import HeifFile
+from .heif import BaseImage, HeifFile
 from .misc import (
     CtxEncode,
     _exif_from_pillow,
@@ -42,7 +42,11 @@ class _LibHeifImageFile(ImageFile.ImageFile):
     def _open(self):
         try:
             # when Pillow starts supporting 16-bit multichannel images change `convert_hdr_to_8bit` to False
-            heif_file = HeifFile(self.fp, convert_hdr_to_8bit=True, hdr_to_16bit=True, remove_stride=False)
+            # `remove_stride` compacts the rows in place, which is what makes the decoded plane
+            # usable as Pillow image storage even when `libheif` padded it to its alignment
+            heif_file = HeifFile(
+                self.fp, convert_hdr_to_8bit=True, hdr_to_16bit=True, remove_stride=True, pillow_layout=True
+            )
         except (OSError, ValueError, SyntaxError, RuntimeError, EOFError) as exception:
             raise SyntaxError(str(exception)) from None
         self.custom_mimetype = heif_file.mimetype
@@ -55,10 +59,11 @@ class _LibHeifImageFile(ImageFile.ImageFile):
         if self._heif_file:
             frame_heif = self._heif_file[self.tell()]
             try:
-                data = frame_heif.data  # Size of Image can change during decoding
-                self._size = frame_heif.size  # noqa
-                self.load_prepare()
-                self.frombytes(data, "raw", (frame_heif.mode, frame_heif.stride))
+                # `HeifImage.to_pillow` also fills `info`, which this class builds on its own;
+                # the decoded plane becomes the image storage itself, Pillow copies it on write
+                image = BaseImage.to_pillow(frame_heif)  # size of the image can change during decoding
+                self._size = image.size  # noqa
+                self.im = image.im
             except (EOFError, ValueError):
                 if not ImageFile.LOAD_TRUNCATED_IMAGES:
                     raise

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -13,6 +13,7 @@ from .misc import (
     MODE_INFO,
     CtxEncode,
     MimCImage,
+    _as_pillow,
     _exif_from_pillow,
     _get_bytes,
     _get_heif_meta,
@@ -78,16 +79,39 @@ class BaseImage:
     def __array_interface__(self):
         """Numpy array interface support."""
         self.load()
-        width = int(self.stride / MODE_INFO[self.mode][0])
-        if MODE_INFO[self.mode][1] <= 8:
-            typestr = "|u1"
-        else:
-            width = int(width / 2)
-            typestr = "<u2"
+        channels, bits = MODE_INFO[self.mode][:2]
+        item_size = 2 if bits > 8 else 1
+        plane_channels = getattr(self._c_image, "plane_channels", channels)
+        width = self.stride // (plane_channels * item_size)
         shape: tuple[Any, ...] = (self.size[1], width)
-        if MODE_INFO[self.mode][0] > 1:
-            shape += (MODE_INFO[self.mode][0],)
-        return {"shape": shape, "typestr": typestr, "version": 3, "data": self.data}
+        if channels > 1:
+            shape += (channels,)
+        interface = {"shape": shape, "typestr": "<u2" if item_size == 2 else "|u1", "version": 3, "data": self.data}
+        # with `pillow_layout` a pixel of the plane is wider than its `channels`, the unused byte is stepped over
+        if plane_channels != channels:
+            interface["strides"] = (self.stride, plane_channels * item_size, item_size)
+        return interface
+
+    def __arrow_c_schema__(self):
+        """`Arrow C data interface <https://arrow.apache.org/docs/format/CDataInterface.html>`_ support."""
+        return self._arrow_source().__arrow_c_schema__()
+
+    # a schema request is best-effort by the interface, the decoded data is offered as it is
+    def __arrow_c_array__(self, requested_schema=None):  # pylint: disable=unused-argument
+        """`Arrow C data interface <https://arrow.apache.org/docs/format/CDataInterface.html>`_ support.
+
+        The decoded data is shared with the consumer and not copied, so it must be treated as read-only.
+
+        16-bit images are exported as ``int16`` — the format `Pillow` itself uses for ``I;16`` images —
+        so for arithmetic on the values reinterpret them as ``uint16``.
+        """
+        self.load()
+        return self._arrow_source().__arrow_c_array__()
+
+    def _arrow_source(self):
+        if not hasattr(self._c_image, "__arrow_c_array__"):
+            raise ValueError("Arrow interface is available only for images decoded from a file.")
+        return self._c_image
 
     def to_pillow(self) -> Image.Image:
         """Helper method to create :external:py:class:`~PIL.Image.Image` class.
@@ -95,14 +119,7 @@ class BaseImage:
         :returns: :external:py:class:`~PIL.Image.Image` class created from an image.
         """
         self.load()
-        return Image.frombytes(
-            self.mode,  # noqa
-            self.size,
-            self.data,
-            "raw",
-            self.mode,
-            self.stride,
-        )
+        return _as_pillow(self._c_image, self.mode, self.size, self.data, self.stride)
 
     def load(self) -> None:
         """Method to decode image.
@@ -281,6 +298,7 @@ class HeifFile:
                 kwargs.get("hdr_to_16bit", True),
                 preferred_decoder,
                 options.DISABLE_SECURITY_LIMITS,
+                kwargs.get("pillow_layout", False),
             )
         self.mimetype = mimetype
         self._images: list[HeifImage] = [HeifImage(i) for i in images if i is not None]
@@ -559,6 +577,13 @@ def open_heif(fp, convert_hdr_to_8bit=True, bgr_mode=False, **kwargs) -> HeifFil
         should be converted to 16-bit mode during decoding. `Has lower priority than convert_hdr_to_8bit`!
         Default = **True**
 
+        **pillow_layout** a boolean value indicating that images should be decoded for `Pillow`:
+        8-bit `RGB` images get the four bytes per pixel layout `Pillow` keeps images in, and
+        :py:meth:`~pillow_heif.HeifImage.to_pillow` shares the decoded data with the created image
+        instead of copying it, so that image is read-only until it is changed. `data` and `stride`
+        of an `RGB` image decoded this way have four bytes per pixel, with the fourth one unused.
+        Default = **False**
+
     :returns: :py:class:`~pillow_heif.HeifFile` object.
     :exception ValueError: invalid input data.
     :exception EOFError: corrupted image data.
@@ -583,6 +608,13 @@ def read_heif(fp, convert_hdr_to_8bit=True, bgr_mode=False, **kwargs) -> HeifFil
     :param kwargs: **hdr_to_16bit** a boolean value indicating that 10/12-bit image data
         should be converted to 16-bit mode during decoding. `Has lower priority than convert_hdr_to_8bit`!
         Default = **True**
+
+        **pillow_layout** a boolean value indicating that images should be decoded for `Pillow`:
+        8-bit `RGB` images get the four bytes per pixel layout `Pillow` keeps images in, and
+        :py:meth:`~pillow_heif.HeifImage.to_pillow` shares the decoded data with the created image
+        instead of copying it, so that image is read-only until it is changed. `data` and `stride`
+        of an `RGB` image decoded this way have four bytes per pixel, with the fourth one unused.
+        Default = **False**
 
     :returns: :py:class:`~pillow_heif.HeifFile` object.
     :exception ValueError: invalid input data.

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -87,6 +87,31 @@ MAX_ITEMS_ERROR = (
     "File with grid images cannot have more than 1000 items (tiles, thumbnails, metadata), increase `tile_size`."
 )
 
+# Pillow stores every multi-band image as four bytes per pixel and a single-band one as one or two,
+# so it can borrow a decoded plane only for these modes, and only when the plane has that exact layout.
+PILLOW_PIXEL_SIZE = {
+    "L": 1,
+    "I;16": 2,
+    "RGB": 4,
+    "RGBA": 4,
+    "RGBa": 4,
+}
+
+
+def _as_pillow(c_image, mode: str, size: tuple[int, int], data, stride: int) -> Image.Image:
+    """Creates a Pillow image, sharing the decoded plane with it when Pillow can use the plane as is."""
+    pixel_size = PILLOW_PIXEL_SIZE.get(mode)
+    # with `pillow_layout` an `RGB` plane has four bytes per pixel, the fourth one unused;
+    # a three byte `RGB` plane cannot be borrowed even when padding makes its stride `width * 4`
+    rgbx_plane = mode == "RGB" and getattr(c_image, "plane_channels", 3) == 4
+    # only a `pillow_layout` image shares its plane, the default decode is always copied
+    borrowable = getattr(c_image, "pillow_layout", 0) and pixel_size is not None and (mode != "RGB" or rgbx_plane)
+    # a stride of its own means another pixel size or padding between the rows
+    if borrowable and stride == size[0] * pixel_size and hasattr(c_image, "__arrow_c_array__"):
+        return Image.fromarrow(c_image, mode, size)  # noqa
+    raw_mode = "RGBX" if rgbx_plane else mode
+    return Image.frombytes(mode, size, data, "raw", raw_mode, stride)  # noqa
+
 
 def save_colorspace_chroma(c_image, info: dict) -> None:
     """Converts `chroma` value from `c_image` to useful values and stores them in ``info`` dict."""
@@ -671,6 +696,8 @@ class MimCImage:  # pylint: disable=too-many-instance-attributes
         self.camera_intrinsic_matrix = None
         self.camera_extrinsic_matrix_rot = None
         self.tiling = None
+        self.plane_channels: int = MODE_INFO[mode][0]
+        self.pillow_layout: int = 0
 
     @property
     def size_mode(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ python_requires = >=3.10
 zip_safe = False
 packages = find:
 install_requires =
-    pillow>=11.1.0
+    pillow>=11.3.0
 
 [options.extras_require]
 docs =

--- a/tests/zero_copy_test.py
+++ b/tests/zero_copy_test.py
@@ -1,0 +1,239 @@
+import gc
+from io import BytesIO
+from pathlib import Path
+
+import helpers
+import pytest
+from PIL import Image, ImageSequence
+
+try:
+    import numpy as np
+except ImportError:  # there are no `numpy` wheels for some platforms, like `cp310` on Windows ARM64
+    np = None
+
+import pillow_heif
+
+pillow_heif.register_heif_opener()
+if not helpers.hevc_enc():
+    pytest.skip(reason="Requires HEVC encoder.", allow_module_level=True)
+
+# `libheif` aligns the stride to 16 bytes, so a decoded plane needs compacting for most widths
+WIDTHS = (64, 65, 66, 67, 68, 100, 127, 128)
+
+
+def encoded(mode: str, size: tuple) -> bytes:
+    im = helpers.gradient_rgb().resize(size).convert(mode=mode)
+    buf = BytesIO()
+    pillow_heif.from_pillow(im).save(buf, quality=-1, chroma=444)
+    return buf.getvalue()
+
+
+def borrowed(im: Image.Image) -> bool:
+    """The plane is borrowed exactly when Pillow marked the storage read-only."""
+    return bool(im.im.readonly)
+
+
+@pytest.mark.parametrize("mode", ("L", "RGB", "RGBA"))
+@pytest.mark.parametrize("width", WIDTHS)
+def test_plugin_borrows_the_plane(mode, width):
+    data = encoded(mode, (width, 64))
+    im = Image.open(BytesIO(data))
+    im.load()
+    assert borrowed(im)
+    # same pixels as decoding without the Pillow layout and copying them the old way
+    heif_image = pillow_heif.open_heif(BytesIO(data))[0]
+    expected = Image.frombytes(heif_image.mode, heif_image.size, heif_image.data, "raw", heif_image.mode)
+    assert im.mode == expected.mode
+    helpers.assert_image_equal(im, expected)
+
+
+@pytest.mark.parametrize("mode", ("L", "RGB", "RGBA"))
+def test_to_pillow_borrows_only_with_pillow_layout(mode):
+    data = encoded(mode, (128, 64))
+    # without the flag `to_pillow` copies as it always did, and the image stays writable
+    default = pillow_heif.open_heif(BytesIO(data))[0].to_pillow()
+    assert not borrowed(default)
+    default.load()[0, 0] = default.getpixel((1, 1))
+    assert borrowed(pillow_heif.open_heif(BytesIO(data), pillow_layout=True)[0].to_pillow())
+
+
+@pytest.mark.skipif(np is None, reason="`numpy` not installed")
+@pytest.mark.parametrize("mode", ("L", "RGB", "RGBA"))
+def test_numpy_array_does_not_depend_on_the_layout(mode):
+    data = encoded(mode, (128, 64))
+    expected = np.asarray(pillow_heif.open_heif(BytesIO(data))[0])
+    result = np.asarray(pillow_heif.open_heif(BytesIO(data), pillow_layout=True)[0])
+    assert result.shape == expected.shape
+    assert np.array_equal(result, expected)
+
+
+@pytest.mark.skipif(np is None, reason="`numpy` not installed")
+def test_numpy_array_of_a_padded_pillow_layout_plane():
+    data = encoded("RGB", (101, 64))
+    heif_image = pillow_heif.open_heif(BytesIO(data), remove_stride=False, pillow_layout=True)[0]
+    heif_image.load()
+    assert heif_image.stride != heif_image.size[0] * 4
+    arr = np.asarray(heif_image)
+    # rows are padded, and as always the padding shows up as columns after the image
+    assert arr.shape == (64, heif_image.stride // 4, 3)
+    assert np.array_equal(arr[:, :101], np.asarray(pillow_heif.open_heif(BytesIO(data))[0]))
+
+
+@pytest.mark.parametrize("pillow_layout", (False, True))
+def test_to_pillow_pixels_do_not_depend_on_the_layout(pillow_layout):
+    data = encoded("RGB", (128, 64))
+    expected = pillow_heif.open_heif(BytesIO(data))[0].to_pillow()
+    result = pillow_heif.open_heif(BytesIO(data), pillow_layout=pillow_layout)[0].to_pillow()
+    helpers.assert_image_equal(result, expected)
+
+
+def test_borrowed_image_is_copy_on_write():
+    heif_file = pillow_heif.open_heif(BytesIO(encoded("RGBA", (128, 64))), pillow_layout=True)
+    heif_image = heif_file[0]
+    im = heif_image.to_pillow()
+    assert borrowed(im)
+    before = bytes(heif_image.data[:16])
+    im.putpixel((0, 0), (1, 2, 3, 4))
+    assert im.getpixel((0, 0)) == (1, 2, 3, 4)
+    assert not borrowed(im)  # writing detached the image from the plane
+    assert bytes(heif_image.data[:16]) == before
+
+
+def test_borrowed_image_pixel_access_is_read_only():
+    # Pillow marks borrowed storage read-only, so writing through the object `load` returns fails.
+    # Every other way of changing an image copies it first, see `test_borrowed_image_is_copy_on_write`.
+    im = Image.open(BytesIO(encoded("RGB", (128, 64))))
+    pixels = im.load()
+    assert pixels[0, 0] == im.getpixel((0, 0))
+    with pytest.raises(ValueError, match="readonly"):
+        pixels[0, 0] = (1, 2, 3)
+    im.putpixel((0, 0), (1, 2, 3))  # detaches the image from the plane
+    im.load()[1, 1] = (4, 5, 6)
+    assert im.getpixel((1, 1)) == (4, 5, 6)
+
+
+def test_borrowed_images_do_not_share_writes():
+    heif_image = pillow_heif.open_heif(BytesIO(encoded("RGBA", (128, 64))), pillow_layout=True)[0]
+    first, second = heif_image.to_pillow(), heif_image.to_pillow()
+    original = second.getpixel((5, 5))
+    first.putpixel((5, 5), (9, 9, 9, 9))
+    assert second.getpixel((5, 5)) == original
+
+
+def test_borrowed_image_outlives_the_heif_file():
+    im = Image.open(BytesIO(encoded("RGB", (128, 64))))
+    im.load()
+    assert borrowed(im)
+    expected = im.tobytes()
+    del im.info["depth_images"], im.info["aux"]
+    gc.collect()
+    bytearray(16 * 1024 * 1024)  # churn the allocator over anything that was freed
+    gc.collect()
+    assert im.tobytes() == expected
+
+
+def test_arrow_c_array_shares_the_plane():
+    heif_image = pillow_heif.open_heif(BytesIO(encoded("RGB", (128, 64))), pillow_layout=True)[0]
+    schema_capsule, array_capsule = heif_image.__arrow_c_array__()
+    assert "arrow_schema" in repr(schema_capsule)
+    assert "arrow_array" in repr(array_capsule)
+    assert "arrow_schema" in repr(heif_image.__arrow_c_schema__())
+    im = Image.fromarrow(heif_image, "RGB", heif_image.size)
+    assert borrowed(im)
+    helpers.assert_image_equal(im, heif_image.to_pillow())
+
+
+@pytest.mark.skipif(np is None, reason="`numpy` not installed")
+def test_arrow_shares_a_16bit_plane():
+    im16 = helpers.gradient_rgb().resize((128, 64)).convert("L").convert("I;16")
+    buf = BytesIO()
+    pillow_heif.from_pillow(im16).save(buf, quality=-1)
+    heif_image = pillow_heif.open_heif(BytesIO(buf.getvalue()), convert_hdr_to_8bit=False, pillow_layout=True)[0]
+    assert heif_image.mode == "I;16"
+    im = heif_image.to_pillow()
+    assert borrowed(im)  # `fromarrow` accepts only the `int16` format it uses for `I;16` itself
+    expected = Image.frombytes("I;16", heif_image.size, heif_image.data, "raw", "I;16", heif_image.stride)
+    helpers.assert_image_equal(im, expected)
+    arr = np.asarray(heif_image)
+    assert arr.dtype == np.uint16
+    assert np.array_equal(arr, np.asarray(expected))
+
+
+def test_16bit_color_is_not_borrowable():
+    # Pillow has no 16-bit multichannel modes, only the single channel `I;16` plane can be borrowed
+    heif_image = pillow_heif.open_heif(
+        Path("images/heif/RGB_10__128x128.heif"), convert_hdr_to_8bit=False, pillow_layout=True
+    )[0]
+    heif_image.load()
+    assert heif_image.mode == "RGB;16"
+    assert heif_image._c_image.plane_channels == 3  # `pillow_layout` widens only 8-bit `RGB`
+    assert "arrow_array" in repr(heif_image.__arrow_c_array__()[1])  # other Arrow consumers still can
+    with pytest.raises(ValueError):
+        heif_image.to_pillow()  # as it always was: there is no Pillow mode for it
+
+
+def test_arrow_interface_needs_a_decoded_image():
+    # `from_pillow` keeps the data it was given, there is no decoded plane to share
+    heif_image = pillow_heif.from_pillow(Image.new("RGB", (8, 8)))[0]
+    with pytest.raises(ValueError, match="decoded from a file"):
+        heif_image.__arrow_c_array__()
+    with pytest.raises(ValueError, match="decoded from a file"):
+        heif_image.__arrow_c_schema__()
+    helpers.assert_image_equal(heif_image.to_pillow(), Image.new("RGB", (8, 8)))
+
+
+def test_to_pillow_copies_a_padded_pillow_layout_plane():
+    # four bytes per pixel but with padding between the rows, so it has to be copied as "RGBX"
+    data = encoded("RGB", (101, 64))
+    heif_image = pillow_heif.open_heif(BytesIO(data), remove_stride=False, pillow_layout=True)[0]
+    heif_image.load()
+    assert heif_image._c_image.plane_channels == 4
+    assert heif_image.stride != heif_image.size[0] * 4
+    im = heif_image.to_pillow()
+    assert not borrowed(im)
+    helpers.assert_image_equal(im, pillow_heif.open_heif(BytesIO(data))[0].to_pillow())
+
+
+def test_to_pillow_copies_a_padded_three_byte_plane():
+    # 48 pixels are 144 bytes, which `libheif` pads to exactly 48*4: the stride of the Pillow layout, but not its plane
+    data = encoded("RGB", (48, 64))
+    heif_image = pillow_heif.open_heif(BytesIO(data), remove_stride=False)[0]
+    heif_image.load()
+    assert heif_image.stride == 48 * 4
+    assert heif_image._c_image.plane_channels == 3
+    im = heif_image.to_pillow()
+    assert not borrowed(im)
+    helpers.assert_image_equal(im, pillow_heif.open_heif(BytesIO(data))[0].to_pillow())
+
+
+def test_arrow_c_array_rejects_a_padded_plane():
+    # 101 pixels are 404 bytes, which `libheif` pads to its 16 byte alignment: nothing flat to export
+    heif_image = pillow_heif.open_heif(BytesIO(encoded("RGB", (101, 64))), remove_stride=False, pillow_layout=True)[0]
+    heif_image.load()
+    assert heif_image.stride != heif_image.size[0] * 4
+    with pytest.raises(ValueError, match="padded"):
+        heif_image.__arrow_c_array__()
+
+
+def test_plugin_frames_match_the_heif_file():
+    path = Path("images/heif/zPug_3.heic")
+    heif_file = pillow_heif.open_heif(path)
+    im = Image.open(path)
+    for index, frame in enumerate(ImageSequence.Iterator(im)):
+        frame.load()
+        assert borrowed(frame)
+        assert frame.mode == heif_file[index].mode
+        helpers.assert_image_equal(frame, heif_file[index].to_pillow())
+
+
+def test_borrowed_image_saves_and_converts():
+    data = encoded("RGB", (128, 64))
+    im = Image.open(BytesIO(data))
+    im.load()
+    expected = pillow_heif.open_heif(BytesIO(data))[0].to_pillow()
+    helpers.assert_image_equal(im.convert("L"), expected.convert("L"))
+    helpers.assert_image_equal(im.resize((64, 32)), expected.resize((64, 32)))
+    buf = BytesIO()
+    im.save(buf, format="HEIF", quality=-1, chroma=444)
+    buf.seek(0)
+    helpers.assert_image_equal(Image.open(buf), Image.open(BytesIO(data)))


### PR DESCRIPTION
The Pillow plugin no longer copies the decoded image. 8-bit `RGB` is decoded as `heif_chroma_interleaved_RGBA` so the plane already has the four bytes per pixel layout `Pillow` keeps images in, the rows are compacted in place, and the plane is handed over through the `Arrow C data interface` instead of `frombytes`.

1. Peak memory drops by about a third, wall time is unchanged (arm64 mac, best-of-N, run-to-run noise ±0.4%):

| image | mode | time | peak RSS |
|---|---|---|---|
| `200MP.heic` (200 MP) | RGB | 1452 → 1444 ms | 1924 → 1348 MiB (-30%) |
| `pug.heic` (12 MP) | RGB | 110.7 → 112.1 ms | 107 → 73 MiB (-32%) |
| synthetic (12 MP) | RGBA | 631 → 633 ms | 167 → 121 MiB (-28%) |
| synthetic (12 MP) | L | 195 → 195 ms | 34.9 → 34.8 MiB |

`libheif` writing the fourth byte costs about what the skipped `frombytes` saves, so the win is memory and not time.

2. `remove_stride` is now on in the plugin: `libheif` aligns the stride to 16 bytes, so without compacting the rows only `w % 4 == 0` images could be borrowed. Compacting is a per-row `memmove` and free when the stride is already tight, and it makes every image the plugin can produce take the new path: 45/45 corpus frames, no fallback for any width or mode.

3. A borrowed image is read-only until it is changed, so `im.load()[x, y] = value` now raises `ValueError`. Everything else (`putpixel`, `paste`, `putdata`, `ImageDraw`, `thumbnail`, `ImageOps`) copies the image first and keeps working, checked one by one. Stock `Pillow` behaves the same for the formats it memory-maps: a palette `BMP`, an uncompressed `TGA` or a single-strip `TIFF` opened from a path is read-only too.

4. For `open_heif`/`read_heif` nothing changes by default: `data`, `stride`, numpy and `to_pillow()` behave as before. The new `pillow_layout` option decodes `RGB` in the four byte layout and makes `to_pillow()` share the decoded plane instead of copying it, the same way the plugin does. The Arrow interface of `HeifImage`, `HeifDepthImage` and `HeifAuxImage` is public and documented.

5. Verified: every corpus frame is pixel-identical to the untouched low-level path; `pyarrow` consumes the array and its buffer address equals the `libheif` plane address; +1 refcount per borrowed image, released on drop; RSS over 1600 iterations grows 1.2 MiB and flattens. 46 new tests.

Minimum `Pillow` is raised to `11.3.0` for `Image.fromarrow`, and a new CI job tests against exactly the minimum version.
