### PR TITLE
ci: fix leak tests failing the full Wheels matrix

### DIFF
--- a/tests/leaks_test.py
+++ b/tests/leaks_test.py
@@ -4,6 +4,7 @@ import mmap
 import sys
 from contextlib import suppress
 from io import BytesIO
+from itertools import pairwise
 from os import chdir, path
 from pathlib import Path
 
@@ -75,22 +76,20 @@ def _get_mem_usage() -> float:
 
 def _assert_no_mem_growth(iteration, warmup: int, block: int, tolerance: float = 2.0) -> None:
     # A leak adds the same amount of memory in every block, while a one-time allocator
-    # growth shows up only once, so the last block is the one that gets measured.
+    # growth lands in only one of them, so the smallest per-block growth is what gets checked.
     for _ in range(warmup):
         iteration()
     gc.collect()
-    after_warmup = _get_mem_usage()
-    for _ in range(block):
-        iteration()
-    gc.collect()
-    settled = _get_mem_usage()
-    for _ in range(block):
-        iteration()
-    gc.collect()
-    growth = _get_mem_usage() - settled
+    checkpoints = [_get_mem_usage()]
+    for _ in range(2):
+        for _ in range(block):
+            iteration()
+        gc.collect()
+        checkpoints.append(_get_mem_usage())
+    growth = min(b - a for a, b in pairwise(checkpoints))
     assert growth <= tolerance, (
-        f"memory usage grew by {growth:.2f} MiB during the last {block} iterations "
-        f"({after_warmup:.2f} MiB after warmup, {settled:.2f} MiB after the first block)"
+        f"memory usage grew by {growth:.2f} MiB per {block} iterations "
+        f"(RSS after warmup and each block: {', '.join(f'{c:.2f}' for c in checkpoints)} MiB)"
     )
 
 

--- a/tests/leaks_test.py
+++ b/tests/leaks_test.py
@@ -95,6 +95,7 @@ def _assert_no_mem_growth(iteration, warmup: int, block: int, tolerance: float =
 
 
 @requires_rss
+@requires_refcounting
 def test_mem_growth_is_detected():
     # guards the checks below: they are only meaningful if a leak of this size fails them.
     # `mmap` is used instead of a plain allocation, as it is not served from the allocator


### PR DESCRIPTION
Two fixes for the scheduled/full-matrix Wheels failures:

- `test_mem_growth_is_detected` runs on PyPy while every check it guards is gated by `requires_refcounting`, and RSS measurement on PyPy does not reliably see the injected mmap leak — it failed the PyPy manylinux jobs in the last two scheduled Wheels runs (both arches). Gate the canary the same way as the tests it validates.
- A one-time allocator growth can land in the measured block just as well as in the first one: `test_pillow_plugin_leaks` failed on the sdist job with 0.00 MiB growth in the first block and a 3.05 MiB step in the second. A real leak grows in every block, so check the smallest per-block growth instead of the last one.