### PR TITLE
feat: read and write nominal diffuse white luminance (ndwt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.7.0 - ]
 
+### Added
+
+- Reading and writing nominal diffuse white luminance HDR metadata: `nominal_diffuse_white_luminance` key in `info` dictionary. #468
+
 ## [1.6.0 - 2026-08-31]
 
 ### Added

--- a/docs/reference/HeifImage.rst
+++ b/docs/reference/HeifImage.rst
@@ -92,6 +92,13 @@ HeifImage object
             Like ``nclx_profile`` and ``icc_profile`` they are written back during save;
             remove a key from ``info`` if you do not want it in the output file.
 
+    .. describe:: info["nominal_diffuse_white_luminance"]: int
+
+        Nominal diffuse white luminance(``ndwt``) in units of 0.0001 candelas per square metre.
+        Can be absent; ``0`` is a valid value and selects the default definition of ISO/TS 22028-5.
+        It is written back during save; remove the key from ``info`` if you do not want it
+        in the output file.
+
     .. describe:: info["pixel_aspect_ratio"]: tuple[int, int]
 
         Pixel aspect ratio(``pasp``) as ``(horizontal_spacing, vertical_spacing)``.

--- a/docs/reference/HeifImagePlugin.rst
+++ b/docs/reference/HeifImagePlugin.rst
@@ -25,8 +25,8 @@ HeifImageFile object
             exif, metadata, primary, bit_depth, thumbnails, depth_images, aux, original_orientation
         Optional there can be also such keys:
             xmp, chroma, icc_profile, icc_profile_type, nclx_profile, content_light_level,
-            mastering_display_colour_volume, ambient_viewing_environment, pixel_aspect_ratio,
-            tiling, heif
+            mastering_display_colour_volume, ambient_viewing_environment, nominal_diffuse_white_luminance,
+            pixel_aspect_ratio, tiling, heif
 
     .. describe:: info["original_orientation"]: int
 

--- a/docs/saving-images.rst
+++ b/docs/saving-images.rst
@@ -140,9 +140,9 @@ https://github.com/strukturag/libheif/issues/995
 HDR metadata
 """"""""""""
 
-``content_light_level``, ``mastering_display_colour_volume`` and ``ambient_viewing_environment``
-from ``image.info`` are written to the output file as is, the same as they can be specified as
-``save`` keyword arguments(applies to the primary image):
+``content_light_level``, ``mastering_display_colour_volume``, ``ambient_viewing_environment``
+and ``nominal_diffuse_white_luminance`` from ``image.info`` are written to the output file as is,
+the same as they can be specified as ``save`` keyword arguments(applies to the primary image):
 
     .. code-block:: python
 

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -608,6 +608,17 @@ static PyObject* _CtxWriteImage_set_ambient_viewing_environment(CtxWriteImageObj
     Py_RETURN_NONE;
 }
 
+static PyObject* _CtxWriteImage_set_nominal_diffuse_white_luminance(CtxWriteImageObject* self, PyObject* args) {
+    unsigned int luminance;
+    if (!PyArg_ParseTuple(args, "I", &luminance))
+        return NULL;
+    if (self->handle)
+        heif_image_handle_set_nominal_diffuse_white_luminance(self->handle, luminance);
+    else
+        heif_image_set_nominal_diffuse_white_luminance(self->image, luminance);
+    Py_RETURN_NONE;
+}
+
 static PyObject* _CtxWriteImage_encode(CtxWriteImageObject* self, PyObject* args) {
     /* ctx: CtxWriteObject, primary: int */
     CtxWriteObject* ctx_write;
@@ -771,6 +782,7 @@ static struct PyMethodDef _CtxWriteImage_methods[] = {
     {"set_content_light_level", (PyCFunction)_CtxWriteImage_set_content_light_level, METH_VARARGS},
     {"set_mastering_display_colour_volume", (PyCFunction)_CtxWriteImage_set_mastering_display_colour_volume, METH_VARARGS},
     {"set_ambient_viewing_environment", (PyCFunction)_CtxWriteImage_set_ambient_viewing_environment, METH_VARARGS},
+    {"set_nominal_diffuse_white_luminance", (PyCFunction)_CtxWriteImage_set_nominal_diffuse_white_luminance, METH_VARARGS},
     {"encode", (PyCFunction)_CtxWriteImage_encode, METH_VARARGS},
     {"set_exif", (PyCFunction)_CtxWriteImage_set_exif, METH_VARARGS},
     {"set_xmp", (PyCFunction)_CtxWriteImage_set_xmp, METH_VARARGS},
@@ -1611,6 +1623,13 @@ static PyObject* _CtxImage_ambient_viewing_environment(CtxImageObject* self, voi
         "ambient_light_y", amve.ambient_light_y);
 }
 
+static PyObject* _CtxImage_nominal_diffuse_white_luminance(CtxImageObject* self, void* closure) {
+    /* 0 is a valid stored luminance, only the `has_` function can tell it apart from an absent box */
+    if (!heif_image_handle_has_nominal_diffuse_white_luminance(self->handle))
+        Py_RETURN_NONE;
+    return Py_BuildValue("I", heif_image_handle_get_nominal_diffuse_white_luminance(self->handle));
+}
+
 static PyObject* _CtxImage_tiling(CtxImageObject* self, void* closure) {
     struct heif_image_tiling tiling;
     /* process_image_transformations=1: report display space values, like all other dimensions we expose */
@@ -1687,6 +1706,7 @@ static struct PyGetSetDef _CtxImage_getseters[] = {
     {"content_light_level", (getter)_CtxImage_content_light_level, NULL, NULL, NULL},
     {"mastering_display_colour_volume", (getter)_CtxImage_mastering_display_colour_volume, NULL, NULL, NULL},
     {"ambient_viewing_environment", (getter)_CtxImage_ambient_viewing_environment, NULL, NULL, NULL},
+    {"nominal_diffuse_white_luminance", (getter)_CtxImage_nominal_diffuse_white_luminance, NULL, NULL, NULL},
     {"camera_intrinsic_matrix", (getter)_CtxImage_camera_intrinsic_matrix, NULL, NULL, NULL},
     {"camera_extrinsic_matrix_rot", (getter)_CtxImage_camera_extrinsic_matrix_rot, NULL, NULL, NULL},
     {"tiling", (getter)_CtxImage_tiling, NULL, NULL, NULL},

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -185,9 +185,14 @@ class HeifImage(BaseImage):
         pixel_aspect_ratio = c_image.pixel_aspect_ratio
         if pixel_aspect_ratio:
             self.info["pixel_aspect_ratio"] = pixel_aspect_ratio
-        for key in ("content_light_level", "mastering_display_colour_volume", "ambient_viewing_environment"):
+        for key in (
+            "content_light_level",
+            "mastering_display_colour_volume",
+            "ambient_viewing_environment",
+            "nominal_diffuse_white_luminance",  # 0 is a valid value for it
+        ):
             value = getattr(c_image, key)
-            if value:
+            if value is not None:
                 self.info[key] = value
         tiling = c_image.tiling
         if tiling:
@@ -486,6 +491,7 @@ class HeifFile:
             "content_light_level",
             "mastering_display_colour_volume",
             "ambient_viewing_environment",
+            "nominal_diffuse_white_luminance",
         ]:
             if key in image.info:
                 added_image.info[key] = deepcopy(image.info[key])

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -617,6 +617,9 @@ class CtxEncode:
             im_out.set_ambient_viewing_environment(
                 amve["ambient_illumination"], amve["ambient_light_x"], amve["ambient_light_y"]
             )
+        ndwt = kwargs.get("nominal_diffuse_white_luminance")
+        if ndwt is not None:  # 0 is a valid value
+            im_out.set_nominal_diffuse_white_luminance(ndwt)
 
     def _add_metadata(self, im_out, **kwargs) -> None:
         exif = kwargs.get("exif")
@@ -668,6 +671,7 @@ class MimCImage:  # pylint: disable=too-many-instance-attributes
         self.content_light_level = None
         self.mastering_display_colour_volume = None
         self.ambient_viewing_environment = None
+        self.nominal_diffuse_white_luminance = None
         self.camera_intrinsic_matrix = None
         self.camera_extrinsic_matrix_rot = None
         self.tiling = None

--- a/tests/metadata_etc_test.py
+++ b/tests/metadata_etc_test.py
@@ -259,7 +259,13 @@ HDR_MDCV = {
     "min_display_mastering_luminance": 50,
 }
 HDR_AMVE = {"ambient_illumination": 100000, "ambient_light_x": 15635, "ambient_light_y": 16450}
-HDR_KEYS = ("content_light_level", "mastering_display_colour_volume", "ambient_viewing_environment")
+HDR_NDWT = 2030000  # 203 cd/m2 in units of 0.0001 cd/m2
+HDR_KEYS = (
+    "content_light_level",
+    "mastering_display_colour_volume",
+    "ambient_viewing_environment",
+    "nominal_diffuse_white_luminance",
+)
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
@@ -277,20 +283,23 @@ def test_heif_hdr_metadata_roundtrip(save_format):
     heif_file[0].info["content_light_level"] = HDR_CLLI
     heif_file[0].info["mastering_display_colour_volume"] = HDR_MDCV
     heif_file[0].info["ambient_viewing_environment"] = HDR_AMVE
+    heif_file[0].info["nominal_diffuse_white_luminance"] = HDR_NDWT
     buf1 = BytesIO()
     heif_file.save(buf1, format=save_format)
-    for box_name in (b"clli", b"mdcv", b"amve"):
+    for box_name in (b"clli", b"mdcv", b"amve", b"ndwt"):
         assert box_name in buf1.getvalue()
     heif_out1 = pillow_heif.open_heif(buf1)
     assert heif_out1[0].info["content_light_level"] == HDR_CLLI
     assert heif_out1[0].info["mastering_display_colour_volume"] == HDR_MDCV
     assert heif_out1[0].info["ambient_viewing_environment"] == HDR_AMVE
+    assert heif_out1[0].info["nominal_diffuse_white_luminance"] == HDR_NDWT
     buf2 = BytesIO()
     heif_out1.save(buf2, format=save_format)
     heif_out2 = pillow_heif.open_heif(buf2)
     assert heif_out2[0].info["content_light_level"] == HDR_CLLI
     assert heif_out2[0].info["mastering_display_colour_volume"] == HDR_MDCV
     assert heif_out2[0].info["ambient_viewing_environment"] == HDR_AMVE
+    assert heif_out2[0].info["nominal_diffuse_white_luminance"] == HDR_NDWT
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
@@ -304,12 +313,14 @@ def test_pillow_hdr_metadata_roundtrip(save_format):
         content_light_level=HDR_CLLI,
         mastering_display_colour_volume=HDR_MDCV,
         ambient_viewing_environment=HDR_AMVE,
+        nominal_diffuse_white_luminance=HDR_NDWT,
     )
     im1 = Image.open(buf1)
     im1.load()
     assert im1.info["content_light_level"] == HDR_CLLI
     assert im1.info["mastering_display_colour_volume"] == HDR_MDCV
     assert im1.info["ambient_viewing_environment"] == HDR_AMVE
+    assert im1.info["nominal_diffuse_white_luminance"] == HDR_NDWT
     buf2 = BytesIO()
     im1.save(buf2, format=save_format)
     im2 = Image.open(buf2)
@@ -317,6 +328,19 @@ def test_pillow_hdr_metadata_roundtrip(save_format):
     assert im2.info["content_light_level"] == HDR_CLLI
     assert im2.info["mastering_display_colour_volume"] == HDR_MDCV
     assert im2.info["ambient_viewing_environment"] == HDR_AMVE
+    assert im2.info["nominal_diffuse_white_luminance"] == HDR_NDWT
+
+
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+def test_heif_hdr_metadata_ndwt_zero():
+    heif_file = pillow_heif.HeifFile()
+    heif_file.add_from_pillow(Image.effect_mandelbrot((64, 64), (-3, -2.5, 2, 2.5), 100))
+    heif_file[0].info["nominal_diffuse_white_luminance"] = 0  # valid value, selects the ISO/TS 22028-5 default
+    buf = BytesIO()
+    heif_file.save(buf)
+    assert b"ndwt" in buf.getvalue()
+    heif_out = pillow_heif.open_heif(buf)
+    assert heif_out[0].info["nominal_diffuse_white_luminance"] == 0
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")

--- a/tests/metadata_etc_test.py
+++ b/tests/metadata_etc_test.py
@@ -348,6 +348,7 @@ def test_heif_hdr_metadata_ndwt_zero():
 def test_pillow_hdr_metadata_multiframe(save_format):
     im1 = Image.effect_mandelbrot((64, 64), (-3, -2.5, 2, 2.5), 100)
     im1.info["content_light_level"] = HDR_CLLI
+    im1.info["nominal_diffuse_white_luminance"] = 0
     im2 = Image.effect_mandelbrot((32, 32), (-3, -2.5, 2, 2.5), 100)
     im2.info["content_light_level"] = {"max_content_light_level": 4000, "max_pic_average_light_level": 1000}
     out_buf = BytesIO()
@@ -356,6 +357,8 @@ def test_pillow_hdr_metadata_multiframe(save_format):
     assert heif_out[0].info["content_light_level"] == HDR_CLLI
     assert heif_out[1].info["content_light_level"]["max_content_light_level"] == 4000
     assert "mastering_display_colour_volume" not in heif_out[0].info
+    assert heif_out[0].info["nominal_diffuse_white_luminance"] == 0
+    assert "nominal_diffuse_white_luminance" not in heif_out[1].info
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
@@ -364,12 +367,14 @@ def test_heif_hdr_metadata_grid():
     heif_file.add_from_pillow(Image.effect_mandelbrot((300, 300), (-3, -2.5, 2, 2.5), 100))
     heif_file[0].info["content_light_level"] = HDR_CLLI
     heif_file[0].info["mastering_display_colour_volume"] = HDR_MDCV
+    heif_file[0].info["nominal_diffuse_white_luminance"] = HDR_NDWT
     buf = BytesIO()
     heif_file.save(buf, tile_size=128)
     heif_out = pillow_heif.open_heif(buf)
     assert heif_out[0].info["tiling"]
     assert heif_out[0].info["content_light_level"] == HDR_CLLI
     assert heif_out[0].info["mastering_display_colour_volume"] == HDR_MDCV
+    assert heif_out[0].info["nominal_diffuse_white_luminance"] == HDR_NDWT
 
 
 @pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")


### PR DESCRIPTION
1. new optional key in the `info` dictionary: `nominal_diffuse_white_luminance` - filled from the `ndwt` item property when present, without decoding; follow-up to #456
2. on save the key (or a `save()` kwarg) is written back as an item property
3. the value is the raw code value in units of 0.0001 cd/m2; `0` is valid (selects the ISO/TS 22028-5 default) and roundtrips, so the key uses `is not None` checks instead of truthiness