### PR TITLE
ci: let renovate update every bundled library version reference

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":disableDependencyDashboard",
     "helpers:pinGitHubActionDigests"
   ],
@@ -13,12 +13,24 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^libheif/build_libs\\.py$"],
+      "managerFilePatterns": ["/^libheif/build_libs\\.py$/", "/^LICENSES_bundled\\.txt$/"],
       "matchStrings": [
-        "\"https://github\\.com/(?<depName>strukturag/[a-z0-9]+)/releases/download/v(?<currentValue>[0-9.]+)/"
+        "\"https://github\\.com/(?<depName>strukturag/[a-z0-9]+)/releases/download/v(?<currentValue>[0-9.]+)/[^\"]+\"",
+        "https://github\\.com/(?<depName>strukturag/[a-z0-9]+)/tree/v(?<currentValue>[0-9.]+)"
       ],
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^libheif/windows/mingw-w64-libheif/PKGBUILD$/"],
+      "matchStrings": [
+        "pkgver=(?<version>[0-9.]+)\\nsha256sums=\\('(?<currentDigest>[a-f0-9]{64})'\\)"
+      ],
+      "depNameTemplate": "strukturag/libheif",
+      "datasourceTemplate": "github-release-attachments",
+      "currentValueTemplate": "v{{{version}}}",
+      "autoReplaceStringTemplate": "pkgver={{{replace '^v' '' newValue}}}\nsha256sums=('{{{newDigest}}}')"
     }
   ]
 }

--- a/libheif/build_libs.py
+++ b/libheif/build_libs.py
@@ -43,7 +43,7 @@ def download_file(url: str, out_path: str) -> bool:
             break
     for _ in range(2):
         try:
-            run(["curl", "-L", url, "-o", out_path], timeout=90, stderr=DEVNULL, stdout=DEVNULL, check=True)
+            run(["curl", "-fL", url, "-o", out_path], timeout=90, stderr=DEVNULL, stdout=DEVNULL, check=True)
             return True
         except (CalledProcessError, TimeoutExpired):
             continue
@@ -58,7 +58,8 @@ def download_file(url: str, out_path: str) -> bool:
 def download_extract_to(url: str, out_path: str, strip: bool = True):
     makedirs(out_path, exist_ok=True)
     archive_path = path.join(out_path, "download.tar.gz")
-    download_file(url, archive_path)
+    if not download_file(url, archive_path):
+        raise RuntimeError(f"Failed to download {url}")
     tar_cmd = f"tar -xf {archive_path} -C {out_path}"
     if strip:
         tar_cmd += " --strip-components 1"

--- a/libheif/windows/mingw-w64-libheif/PKGBUILD
+++ b/libheif/windows/mingw-w64-libheif/PKGBUILD
@@ -5,6 +5,7 @@ _realname=libheif
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.23.2
+sha256sums=('8bd5d41d19dc84536d118b04774709f244df6104ef66d623dad5fa4650143405')
 pkgrel=1
 pkgdesc="HEIF image decoder/encoder library and tools (mingw-w64)"
 arch=('any')
@@ -22,7 +23,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libde265"
          "${MINGW_PACKAGE_PREFIX}-x265")
 source=("https://github.com/strukturag/libheif/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('8bd5d41d19dc84536d118b04774709f244df6104ef66d623dad5fa4650143405')
 
 build() {
   mkdir -p "${srcdir}"/build-${MSYSTEM} && cd "${srcdir}"/build-${MSYSTEM}

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -1,6 +1,7 @@
 import builtins
 import contextlib
 import os
+import re
 from pathlib import Path
 
 import dataset
@@ -100,6 +101,11 @@ def test_heif_str():
     assert str(heif_file2) == f"<HeifFile with 1 images: ['{str_img_l_1}']>"
 
 
+def bundled_libheif_version() -> str:
+    build_libs = Path(__file__).resolve().parent.parent / "libheif" / "build_libs.py"
+    return re.search(r"libheif-([0-9.]+)\.tar\.gz", build_libs.read_text()).group(1)
+
+
 @pytest.mark.skipif(not helpers.RELEASE_TESTS_FLAG, reason="Only when running release tests")
 def test_full_build():
     info = pillow_heif.libheif_info()
@@ -107,7 +113,7 @@ def test_full_build():
     assert info["HEIF"]
     assert info["encoders"]
     assert info["decoders"]
-    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", "1.23.2")
+    expected_version = os.getenv("EXP_PH_LIBHEIF_VERSION", bundled_libheif_version())
     if expected_version:
         assert info["libheif"] == expected_version
 


### PR DESCRIPTION
Every Renovate PR bumping `libheif`/`libde265` needed a manual fixup (#434, #445, #466, now #470 and #471): the regex manager matched only up to `/releases/download/vX.Y.Z/`, and Renovate rewrites the version only inside the matched string, so the tarball filename kept the old version and the download 404
