### PR TITLE
fix: out-of-bounds read in encode() when stride is smaller than the row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 - `libde265` was updated from the `1.1.1` to `1.1.2` version. #471
 
+### Fixed
+
+- Out-of-bounds read in `encode()` when `stride` was smaller than the image row width. (GHSA-ccw6-q225-c975) Thanks to @arpitjain099 for finding this!
+
 ## [1.6.0 - 2026-08-31]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 All notable changes to this project will be documented in this file.
 
-## [1.7.0 - ]
+## [1.7.0 - 2026-09-06]
 
 ### Added
 
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `libheif` was updated from the `1.23.2` to `1.23.3` version. #470
 - `libde265` was updated from the `1.1.1` to `1.1.2` version. #471
 
 ### Fixed

--- a/pillow_heif/_pillow_heif.c
+++ b/pillow_heif/_pillow_heif.c
@@ -162,7 +162,8 @@ static PyObject* _CtxWriteImage_add_plane(CtxWriteImageObject* self, PyObject* a
         real_stride = real_stride * 2;
     if (stride_in == 0)
         stride_in = real_stride;
-    if ((Py_ssize_t)stride_in * height > buffer.len) {
+    if ((width <= 0) || (height <= 0) || (real_stride <= 0) || (stride_in < real_stride) ||
+        ((Py_ssize_t)stride_in * height > buffer.len)) {
         PyBuffer_Release(&buffer);
         PyErr_SetString(PyExc_ValueError, "image plane does not contain enough data");
         return NULL;
@@ -352,7 +353,8 @@ static PyObject* _CtxWriteImage_add_plane_la(CtxWriteImageObject* self, PyObject
         real_stride = real_stride * 2;
     if (stride_in == 0)
         stride_in = real_stride;
-    if ((Py_ssize_t)stride_in * height > buffer.len) {
+    if ((width <= 0) || (height <= 0) || (real_stride <= 0) || (stride_in < real_stride) ||
+        ((Py_ssize_t)stride_in * height > buffer.len)) {
         PyBuffer_Release(&buffer);
         PyErr_SetString(PyExc_ValueError, "image plane does not contain enough data");
         return NULL;
@@ -461,7 +463,8 @@ static PyObject* _CtxWriteImage_add_plane_l(CtxWriteImageObject* self, PyObject*
         real_stride = real_stride * 2;
     if (stride_in == 0)
         stride_in = real_stride;
-    if ((Py_ssize_t)stride_in * height > buffer.len) {
+    if ((width <= 0) || (height <= 0) || (real_stride <= 0) || (stride_in < real_stride) ||
+        ((Py_ssize_t)stride_in * height > buffer.len)) {
         PyBuffer_Release(&buffer);
         PyErr_SetString(PyExc_ValueError, "image plane does not contain enough data");
         return NULL;

--- a/tests/overflow_test.py
+++ b/tests/overflow_test.py
@@ -39,3 +39,36 @@ def test_encode_large_dimensions_overflow(mode, size):
     buf = BytesIO()
     with pytest.raises(ValueError, match="does not contain enough data"):
         pillow_heif.encode(mode, size, small_buffer, buf, quality=-1)
+
+
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+@pytest.mark.parametrize("mode", ("RGB", "RGBA", "LA", "L"))
+def test_encode_stride_smaller_than_row(mode):
+    # stride_in passes the `stride_in * height` length check but the copy reads
+    # `real_stride` (width * bytes_per_pixel) bytes per row -> out-of-bounds read
+    buf = BytesIO()
+    with pytest.raises(ValueError, match="does not contain enough data"):
+        pillow_heif.encode(mode, (1000, 2), b"\x00" * 8, buf, quality=-1, stride=1)
+
+
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+@pytest.mark.parametrize("mode", ("RGB", "RGBA", "LA", "L"))
+def test_encode_negative_stride(mode):
+    # a negative stride makes `stride_in * height` negative, passing the length check,
+    # then `in + stride_in * i` reads before the buffer
+    buf = BytesIO()
+    with pytest.raises(ValueError, match="does not contain enough data"):
+        pillow_heif.encode(mode, (100, 10), b"\x00" * (1024 * 1024), buf, quality=-1, stride=-4000)
+
+
+@pytest.mark.skipif(not hevc_enc(), reason="Requires HEVC encoder.")
+@pytest.mark.parametrize("extra", (0, 5))
+def test_encode_padded_stride_ok(extra):
+    # a stride >= the real row width (extra = padding bytes per row) must still be accepted
+    width, height = 64, 32
+    stride = width * 3 + extra
+    buf = BytesIO()
+    pillow_heif.encode("RGB", (width, height), b"\x80" * (stride * height), buf, quality=-1, stride=stride)
+    out = pillow_heif.open_heif(buf)[0]
+    out.load()
+    assert out.size == (width, height)


### PR DESCRIPTION
The plane length check validated `stride * height` but the row copy reads the real row width, so a `stride` smaller than the row (or negative) over-read the buffer. Guarded in the three plane writers, with regression tests. GHSA-ccw6-q225-c975