### PR TITLE
feat: py.typed marker; fix the mypy errors it exposes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,9 @@ jobs:
         run: python3 -m pip install ".[dev]" wheel setuptools
 
       - name: Run Analysis
-        run: python3 -m pylint "setup.py" "pillow_heif/"
+        run: |
+          python3 -m pylint "setup.py" "pillow_heif/"
+          python3 -m mypy "pillow_heif/"
 
   docs:
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Reading and writing nominal diffuse white luminance HDR metadata: `nominal_diffuse_white_luminance` key in `info` dictionary. #468
+- `py.typed` marker, the package type annotations are now visible to type checkers. #475
 
 ### Changed
 
@@ -14,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Out-of-bounds read in `encode()` when `stride` was smaller than the image row width. (GHSA-ccw6-q225-c975) Thanks to @arpitjain099 for finding this!
+- `TypeError` when saving an image whose `info` dictionary contains non-string keys. #475
 
 ## [1.6.0 - 2026-08-31]
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include pyproject.toml
 include .github/wheels-test.py
 
 recursive-include pillow_heif *.c *.h
+include pillow_heif/py.typed
 
 graft libheif
 graft tests

--- a/pillow_heif/as_plugin.py
+++ b/pillow_heif/as_plugin.py
@@ -206,7 +206,7 @@ def __save_all(im: Image.Image, fp: IO[bytes], compression_format: HeifCompressi
 def _pil_encode_image(ctx: CtxEncode, img: Image.Image, primary: bool, **kwargs) -> None:
     if img.size[0] <= 0 or img.size[1] <= 0:
         raise ValueError("Empty images are not supported.")
-    info = img.info.copy()
+    info = {k: v for k, v in img.info.items() if isinstance(k, str)}
     info["exif"] = _exif_from_pillow(img)
     info["xmp"] = _xmp_from_pillow(img)
     info.update(**kwargs)

--- a/pillow_heif/heif.py
+++ b/pillow_heif/heif.py
@@ -1,5 +1,6 @@
 """Functions and classes for heif images to read and write."""
 
+from collections.abc import Iterator
 from copy import copy, deepcopy
 from io import SEEK_SET
 from threading import Lock
@@ -409,18 +410,18 @@ class HeifFile:
     def __repr__(self):
         return f"<{self.__class__.__name__} with {len(self)} images: {[str(i) for i in self]}>"
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._images)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[HeifImage]:
         yield from self._images
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> HeifImage:
         if index < 0 or index >= len(self._images):
             raise IndexError(f"invalid image index: {index}")
         return self._images[index]
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: int) -> None:
         if key < 0 or key >= len(self._images):
             raise IndexError(f"invalid image index: {key}")
         del self._images[key]

--- a/pillow_heif/misc.py
+++ b/pillow_heif/misc.py
@@ -6,7 +6,6 @@ Mostly for internal use, so prototypes can change between versions.
 import builtins
 import re
 from dataclasses import dataclass
-from enum import IntEnum
 from math import ceil
 from pathlib import Path
 from struct import pack, unpack
@@ -288,29 +287,17 @@ def _pil_to_supported_mode(img: Image.Image) -> Image.Image:
     return img
 
 
-class Transpose(IntEnum):
-    """Temporary workaround till we support old Pillows, remove this when a minimum Pillow version will have this."""
-
-    FLIP_LEFT_RIGHT = 0
-    FLIP_TOP_BOTTOM = 1
-    ROTATE_90 = 2
-    ROTATE_180 = 3
-    ROTATE_270 = 4
-    TRANSPOSE = 5
-    TRANSVERSE = 6
-
-
 def _rotate_pil(img: Image.Image, orientation: int) -> Image.Image:
     # Probably need create issue in Pillow to add support
     # for info["xmp"] or `getxmp()` for ImageOps.exif_transpose and remove this func.
     method = {
-        2: Transpose.FLIP_LEFT_RIGHT,
-        3: Transpose.ROTATE_180,
-        4: Transpose.FLIP_TOP_BOTTOM,
-        5: Transpose.TRANSPOSE,
-        6: Transpose.ROTATE_270,
-        7: Transpose.TRANSVERSE,
-        8: Transpose.ROTATE_90,
+        2: Image.Transpose.FLIP_LEFT_RIGHT,
+        3: Image.Transpose.ROTATE_180,
+        4: Image.Transpose.FLIP_TOP_BOTTOM,
+        5: Image.Transpose.TRANSPOSE,
+        6: Image.Transpose.ROTATE_270,
+        7: Image.Transpose.TRANSVERSE,
+        8: Image.Transpose.ROTATE_90,
     }.get(orientation)
     if method is not None:
         return img.transpose(method)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
     Operating System :: Microsoft :: Windows
+    Typing :: Typed
 license = BSD-3-Clause
 project_urls =
     Documentation=https://pillow-heif.readthedocs.io
@@ -63,5 +64,6 @@ dev =
     opencv-python==5.0.0.93
     pre-commit
     pylint
+    mypy
     coverage
     setuptools

--- a/tests/write_test.py
+++ b/tests/write_test.py
@@ -31,6 +31,14 @@ def test_save_format(save_format):
     assert mime == "image/heic"
 
 
+def test_save_ignores_non_str_info_keys():
+    im = helpers.gradient_rgb()
+    im.info[1, 2] = "value"
+    buf = BytesIO()
+    im.save(buf, format="HEIF")
+    assert pillow_heif.open_heif(buf)[0].size == im.size
+
+
 @pytest.mark.parametrize(
     "img",
     (


### PR DESCRIPTION
1. `pillow_heif/py.typed` PEP 561 marker (in the wheel and sdist) + `Typing :: Typed` classifier, so type checkers finally see the existing annotations
2. fixes the 3 mypy errors that shipping the annotations would expose:
   - `_pil_encode_image` splatted `img.info` whose keys Pillow types as `str | tuple[int, int]` - a tuple key was a real `TypeError: keywords must be strings` on save, now non-str keys are filtered out (with a regression test)
   - the local `Transpose` copy in `misc.py` is removed per its own docstring - minimum Pillow is `11.1.0`, `Image.Transpose` is there since `9.1`
3. `HeifFile.__len__/__iter__/__getitem__/__delitem__` annotated, so `heif_file[0]` is typed as `HeifImage` for downstream checkers instead of `Any`
4. `mypy pillow_heif/` added to the Analysis CI job to keep the now-public annotations from rotting